### PR TITLE
First pass at .NET core port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/output
 *.nupkg
 *.orig
 *.DotSettings
+*.lock.json

--- a/src/D2L.Security.OAuth2/Keys/Caching/InMemoryPublicKeyCache.cs
+++ b/src/D2L.Security.OAuth2/Keys/Caching/InMemoryPublicKeyCache.cs
@@ -1,5 +1,11 @@
-﻿using System;
+using System;
+
+#if !DNXCORE50
 using System.Runtime.Caching;
+#else
+using Microsoft.Framework.Caching.Memory;
+#endif
+
 using D2L.Security.OAuth2.Keys.Default;
 
 namespace D2L.Security.OAuth2.Keys.Caching {

--- a/src/D2L.Security.OAuth2/Validation/Request/HttpRequestExtensions.cs
+++ b/src/D2L.Security.OAuth2/Validation/Request/HttpRequestExtensions.cs
@@ -1,8 +1,9 @@
-﻿using System.Web;
+#if !DNXCORE50
+
+using System.Web;
 
 namespace D2L.Security.OAuth2.Validation.Request {
 	internal static class HttpRequestExtensions {
-
 		/// <param name="request">The request</param>
 		/// <returns>The value of the auth cookie, or null if one was not found</returns>
 		internal static string GetCookieValue( this HttpRequest request ) {
@@ -37,3 +38,5 @@ namespace D2L.Security.OAuth2.Validation.Request {
 		}
 	}
 }
+
+#endif

--- a/src/D2L.Security.OAuth2/Validation/Request/IRequestAuthenticator.cs
+++ b/src/D2L.Security.OAuth2/Validation/Request/IRequestAuthenticator.cs
@@ -1,23 +1,24 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 using System.Threading.Tasks;
+
+#if !DNXCORE50
 using System.Web;
+#endif
 
 using D2L.Security.OAuth2.Principal;
 using D2L.Security.OAuth2.Validation.AccessTokens;
 
 namespace D2L.Security.OAuth2.Validation.Request {
-
 	/// <summary>
-	/// An abstraction for authenticating access tokens that works at the request level 
+	/// An abstraction for authenticating access tokens that works at the request level
 	/// rather than the token level (see <see cref="IAccessTokenValidator"/>)
 	/// </summary>
 	public interface IRequestAuthenticator {
-
 		/// <summary>
 		/// Authenticates a token contained in an <see cref="HttpRequestMessage"/>
 		/// </summary>
 		/// <param name="request">The web request object</param>
-		/// <param name="authMode">The authentication mode; xsrf validation should NOT be 
+		/// <param name="authMode">The authentication mode; xsrf validation should NOT be
 		/// skipped for requests coming from a browser</param>
 		/// <returns>An <see cref="ID2LPrincipal"/> for an authenticated user.</returns>
 		Task<ID2LPrincipal> AuthenticateAsync(
@@ -25,16 +26,18 @@ namespace D2L.Security.OAuth2.Validation.Request {
 			AuthenticationMode authMode = AuthenticationMode.Full
 		);
 
+#if !DNXCORE50
 		/// <summary>
 		/// Authenticates a token contained in an <see cref="HttpRequest"/>
 		/// </summary>
 		/// <param name="request">The web request object.</param>
-		/// <param name="authMode">The authentication mode. Xsrf validation should NOT 
+		/// <param name="authMode">The authentication mode. Xsrf validation should NOT
 		/// be skipped for requests coming from a browser</param>
 		/// <returns>An <see cref="ID2LPrincipal"/> for an authenticated user.</returns>
 		Task<ID2LPrincipal> AuthenticateAsync(
 			HttpRequest request,
 			AuthenticationMode authMode = AuthenticationMode.Full
 		);
+#endif
 	}
 }

--- a/src/D2L.Security.OAuth2/Validation/Request/RequestAuthenticator.cs
+++ b/src/D2L.Security.OAuth2/Validation/Request/RequestAuthenticator.cs
@@ -1,7 +1,11 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+
+#if !DNXCORE50
 using System.Web;
+#endif
+
 using D2L.Security.OAuth2.Principal;
 using D2L.Security.OAuth2.Validation.AccessTokens;
 using D2L.Security.OAuth2.Validation.Exceptions;
@@ -28,6 +32,7 @@ namespace D2L.Security.OAuth2.Validation.Request {
 			return AuthenticateHelper( cookie, xsrfToken, bearerToken, authMode );
 		}
 
+#if !DNXCORE50
 		Task<ID2LPrincipal> IRequestAuthenticator.AuthenticateAsync(
 			HttpRequest request,
 			AuthenticationMode authMode
@@ -38,6 +43,7 @@ namespace D2L.Security.OAuth2.Validation.Request {
 
 			return AuthenticateHelper( cookie, xsrfToken, bearerToken, authMode );
 		}
+#endif
 
 		private async Task<ID2LPrincipal> AuthenticateHelper(
 			string cookie,

--- a/src/D2L.Security.OAuth2/project.json
+++ b/src/D2L.Security.OAuth2/project.json
@@ -1,0 +1,26 @@
+﻿{
+    "version": "4.3.3-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "dependencies": {
+        "Microsoft.Framework.Caching.Memory": "1.0.0-beta-*",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
+        "System.IO": "4.0.11-beta-*",
+        "System.Collections.Concurrent": "4.0.11-beta-*",
+        "System.Console": "4.0.0-beta-*",
+        "System.IdentityModel.Tokens": "5.0.0-*",
+        "System.IdentityModel.Tokens.Jwt": "5.0.0-*",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Net.Http": "4.0.1-beta-*",
+        "System.Runtime": "4.0.21-beta-*",
+        "System.Runtime.Serialization.Json": "4.0.1-beta-*",
+        "System.Security.Cryptography.Cng": "4.0.0-beta-*",
+        "System.Security.Cryptography.RSA": "4.0.0-beta-*",
+        "System.Security.Claims": "4.0.1-beta-*"
+    },
+    "frameworks": {
+        "dnxcore50": { },
+        "net451": { }
+    }
+}


### PR DESCRIPTION
See issue #6
Need to confirm that AppVeyor will ignore the `project.json`/prefer the sln.