### PR TITLE
Move AuthenticateAs extension from HttpClient to HttpRequestMessage to encourage secure usage of tokens

### DIFF
--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -57,7 +57,7 @@
     <Compile Include="Caching\CacheResponse.cs" />
     <Compile Include="Caching\ICache.cs" />
     <Compile Include="Caching\NullCache.cs" />
-    <Compile Include="Extensions\System.Net.Http.HttpClient.Extensions.cs" />
+    <Compile Include="Extensions\System.Net.Http.HttpRequestMessage.Extensions.cs" />
     <Compile Include="Keys\Default\D2LSecurityToken.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Keys\Caching\InMemoryPublicKeyCache.cs" />

--- a/src/D2L.Security.OAuth2/Extensions/System.Net.Http.HttpRequestMessage.Extensions.cs
+++ b/src/D2L.Security.OAuth2/Extensions/System.Net.Http.HttpRequestMessage.Extensions.cs
@@ -12,8 +12,8 @@ namespace D2L {
 		/// </summary>
 		/// <param name="this"></param>
 		/// <param name="principal">This principals access token will be used</param>
-		public static void AuthenticateAs( this HttpClient @this, ID2LPrincipal principal ) {
-			@this.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+		public static void AuthenticateAs( this HttpRequestMessage @this, ID2LPrincipal principal ) {
+			@this.Headers.Authorization = new AuthenticationHeaderValue(
 				scheme: "Bearer",
 				parameter: principal.AccessToken.SensitiveRawAccessToken
 			);	


### PR DESCRIPTION
Fixes #17 