### PR TITLE
Use project references internally only, not nuget packages

### DIFF
--- a/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.csproj
+++ b/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.csproj
@@ -36,11 +36,6 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="D2L.Security.OAuth2, Version=4.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\D2L.Security.OAuth2.4.4.0.0\lib\net451\D2L.Security.OAuth2.dll</HintPath>
-      <HintPath>..\D2L.Security.OAuth2\bin\Debug\D2L.Security.OAuth2.dll</HintPath>
-    </Reference>
     <Reference Include="D2L.Services.Core.Extensions, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\D2L.Services.Core.Extensions.1.1.1.0\lib\net451\D2L.Services.Core.Extensions.dll</HintPath>
       <Private>True</Private>
@@ -85,6 +80,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\D2L.Security.OAuth2\D2L.Security.OAuth2.csproj">
+      <Project>{676fb8c0-d021-475e-941b-03be21769294}</Project>
+      <Name>D2L.Security.OAuth2</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.nuspec
+++ b/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.nuspec
@@ -11,5 +11,9 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>$description$</description>
 		<copyright>Copyright 2016</copyright>
+		
+		<dependencies>
+			<dependency id="D2L.Security.OAuth2" version="$version$" />
+		</dependencies>
 	</metadata>
 </package>

--- a/src/D2L.Security.OAuth2.WebApi/packages.config
+++ b/src/D2L.Security.OAuth2.WebApi/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="D2L.Security.OAuth2" version="5.0.2.0" targetFramework="net451" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />

--- a/test/D2L.Security.OAuth2.WebApi.IntegrationTests/D2L.Security.OAuth2.WebApi.IntegrationTests.csproj
+++ b/test/D2L.Security.OAuth2.WebApi.IntegrationTests/D2L.Security.OAuth2.WebApi.IntegrationTests.csproj
@@ -33,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="D2L.Security.OAuth2, Version=4.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\src\D2L.Security.OAuth2\bin\Debug\D2L.Security.OAuth2.dll</HintPath>
-    </Reference>
     <Reference Include="D2L.Services.Core.Extensions">
       <HintPath>..\..\packages\D2L.Services.Core.Extensions.1.1.1.0\lib\net451\D2L.Services.Core.Extensions.dll</HintPath>
     </Reference>
@@ -113,6 +109,10 @@
     <ProjectReference Include="..\..\src\D2L.Security.OAuth2.WebApi\D2L.Security.OAuth2.WebApi.csproj">
       <Project>{c9140879-73e6-4767-b12b-17581793e419}</Project>
       <Name>D2L.Security.OAuth2.WebApi</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\D2L.Security.OAuth2\D2L.Security.OAuth2.csproj">
+      <Project>{676fb8c0-d021-475e-941b-03be21769294}</Project>
+      <Name>D2L.Security.OAuth2</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/D2L.Security.OAuth2.WebApi.IntegrationTests/packages.config
+++ b/test/D2L.Security.OAuth2.WebApi.IntegrationTests/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AspNetWebApi.SelfHost" version="4.0.20710.0" targetFramework="net452" />
-  <package id="D2L.Security.OAuth2" version="4.4.0.0" targetFramework="net451" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />

--- a/test/D2L.Security.OAuth2.WebApi.UnitTests/D2L.Security.OAuth2.WebApi.UnitTests.csproj
+++ b/test/D2L.Security.OAuth2.WebApi.UnitTests/D2L.Security.OAuth2.WebApi.UnitTests.csproj
@@ -32,10 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="D2L.Security.OAuth2, Version=4.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\src\D2L.Security.OAuth2\bin\Debug\D2L.Security.OAuth2.dll</HintPath>
-    </Reference>
     <Reference Include="D2L.Services.Core.Extensions, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\D2L.Services.Core.Extensions.1.1.1.0\lib\net451\D2L.Services.Core.Extensions.dll</HintPath>
@@ -92,6 +88,10 @@
     <ProjectReference Include="..\..\src\D2L.Security.OAuth2.WebApi\D2L.Security.OAuth2.WebApi.csproj">
       <Project>{c9140879-73e6-4767-b12b-17581793e419}</Project>
       <Name>D2L.Security.OAuth2.WebApi</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\D2L.Security.OAuth2\D2L.Security.OAuth2.csproj">
+      <Project>{676fb8c0-d021-475e-941b-03be21769294}</Project>
+      <Name>D2L.Security.OAuth2</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/D2L.Security.OAuth2.WebApi.UnitTests/packages.config
+++ b/test/D2L.Security.OAuth2.WebApi.UnitTests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="D2L.Security.OAuth2" version="4.4.0.0" targetFramework="net451" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net451" />
   <package id="FluentAssertions" version="3.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
Continuing on #31 

This moves all references to D2L.Security.OAuth2 to project references within this solution.

Nuget has an option IncludeReferencedProjects which looks like basically what we want ( https://docs.nuget.org/consume/command-line-reference )

Before Daryl pointed that out for me I came up with this. Turns out that AppVeyor doesn't "support" that yet and one of the workarounds in the issue was to do what I'm doing here. http://help.appveyor.com/discussions/suggestions/449-add-includereferencedprojects-to-nuget-pack-command

I manually built the WebApi package and verified that it only had the WebApi DLL and that its dependency list in the packed/compiled nuspec was sensible.