### PR TITLE
Update OAuth2AuthorizeAttribute.cs

### DIFF
--- a/src/D2L.Security.OAuth2.WebApi/Authorization/OAuth2AuthorizeAttribute.cs
+++ b/src/D2L.Security.OAuth2.WebApi/Authorization/OAuth2AuthorizeAttribute.cs
@@ -18,13 +18,13 @@ namespace D2L.Security.OAuth2.Authorization {
 
 			var actionAttributes = actionContext
 				.ActionDescriptor
-				.GetCustomAttributes<OAuth2AuthorizeAttribute>( inherit: false );
+				.GetCustomAttributes<OAuth2AuthorizeAttribute>();
 			var actionAttributeTypes = actionAttributes
 				.Select( x => x.GetType() );
 			var controllerAttributes = actionContext
 				.ActionDescriptor
 				.ControllerDescriptor
-				.GetCustomAttributes<OAuth2AuthorizeAttribute>( inherit: false );
+				.GetCustomAttributes<OAuth2AuthorizeAttribute>();
 
 			var oauth2Attributes = actionAttributes
 				.Union( controllerAttributes.Where( x => !actionAttributeTypes.Contains( x.GetType() ) ) )

--- a/src/D2L.Security.OAuth2.WebApi/Authorization/OAuth2AuthorizeAttribute.cs
+++ b/src/D2L.Security.OAuth2.WebApi/Authorization/OAuth2AuthorizeAttribute.cs
@@ -18,13 +18,13 @@ namespace D2L.Security.OAuth2.Authorization {
 
 			var actionAttributes = actionContext
 				.ActionDescriptor
-				.GetCustomAttributes<OAuth2AuthorizeAttribute>();
+				.GetCustomAttributes<OAuth2AuthorizeAttribute>( inherit: true );
 			var actionAttributeTypes = actionAttributes
 				.Select( x => x.GetType() );
 			var controllerAttributes = actionContext
 				.ActionDescriptor
 				.ControllerDescriptor
-				.GetCustomAttributes<OAuth2AuthorizeAttribute>();
+				.GetCustomAttributes<OAuth2AuthorizeAttribute>( inherit: true );
 
 			var oauth2Attributes = actionAttributes
 				.Union( controllerAttributes.Where( x => !actionAttributeTypes.Contains( x.GetType() ) ) )


### PR DESCRIPTION
Remove inheritance restriction to allow this attribute to be inherited from Abstract classes.
Resulted from investigation of : https://rally1.rallydev.com/#/23525809118d/detail/userstory/57136951529
[MetronAPI] Add new default scope for Metron API routes