### PR TITLE
Fix Permission Validation

### DIFF
--- a/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
+++ b/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
@@ -30,12 +30,10 @@ namespace D2L.Security.OAuth2.Scopes {
 			var resourceScopes = groupScopes
 				.Where( s => IsMatch( s.Resource, requiredScope.Resource ) );
 
-			var permissionScopes = resourceScopes
-				.Where( s => s.Permissions.Any(
-					p => requiredScope.Permissions.All( rp => IsMatch( p, rp ) )
-				) );
+			var authorized = requiredScope.Permissions
+				.All( rp => resourceScopes.Any( r => r.Permissions.Any( p => IsMatch( p, rp )) ) );
 
-			return permissionScopes.Any();
+			return authorized;
 		}
 
 		private static bool IsMatch( string pattern, string actual ) {

--- a/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
+++ b/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
@@ -32,7 +32,7 @@ namespace D2L.Security.OAuth2.Scopes {
 
 			var permissionScopes = resourceScopes
 				.Where( s => s.Permissions.Any(
-					p => IsMatch( p, requiredScope.Permissions[0] )
+					p => requiredScope.Permissions.All( rp => IsMatch( p, rp ) )
 				) );
 
 			return permissionScopes.Any();

--- a/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
+++ b/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
@@ -31,7 +31,8 @@ namespace D2L.Security.OAuth2.Scopes {
 				.Where( s => IsMatch( s.Resource, requiredScope.Resource ) );
 
 			var grantedPermissions = resourceScopes
-				.SelectMany( s => s.Permissions );
+				.SelectMany( s => s.Permissions )
+				.ToArray();
 
 			var authorized = requiredScope.Permissions
 				.All( rp => grantedPermissions.Any( p => IsMatch( p, rp ) ) );

--- a/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
+++ b/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
@@ -30,8 +30,11 @@ namespace D2L.Security.OAuth2.Scopes {
 			var resourceScopes = groupScopes
 				.Where( s => IsMatch( s.Resource, requiredScope.Resource ) );
 
+			var grantedPermissions = resourceScopes
+				.SelectMany( s => s.Permissions );
+
 			var authorized = requiredScope.Permissions
-				.All( rp => resourceScopes.Any( r => r.Permissions.Any( p => IsMatch( p, rp )) ) );
+				.All( rp => grantedPermissions.Any( p => IsMatch( p, rp ) ) );
 
 			return authorized;
 		}

--- a/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
@@ -16,7 +16,8 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		[TestCase( "g:r:p", "g:r:p", Description = "Grant exact scope" )]
-		[TestCase( "g:r:p,p2", "g:r:p", Description = "Grant extra permissions" )]
+		[TestCase( "g:r:p,p2", "g:r:p", Description = "Grant first permission" )]
+		[TestCase( "g:r:p,p2", "g:r:p2", Description = "Grant second permission" )]
 		[TestCase( "g:r:*", "g:r:p", Description = "Grant all permissions on exact resource in exact group" )]
 		[TestCase( "g:*:*", "g:r:p", Description = "Grant all permissions on all resources in exact group" )]
 		[TestCase( "*:*:*", "g:r:p", Description = "Grant all permissions on all resources in all groups" )]
@@ -34,6 +35,7 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		[TestCase( "g:r:p2", "g:r:p", Description = "Permission does not match" )]
+		[TestCase( "g:r:p,p2", "g:r:p,p3", Description = "Extra permission is not granted" )]
 		[TestCase( "g:r2:p", "g:r:p", Description = "Resource does not match" )]
 		[TestCase( "g2:r:p", "g:r:p", Description = "Group does not match" )]
 		[TestCase( "*:*:p2", "g:r:p", Description = "Permission does not match - with wildcards" )]

--- a/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
@@ -16,6 +16,8 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		[TestCase( "g:r:p", "g:r:p", Description = "Grant exact scope" )]
+		[TestCase( "a:b:c,d", "a:b:c,d", Description = "Grant multiple scope exactly" )]
+		[TestCase( "a:b:c,d", "a:b:d,c", Description = "Grant multiple scope exactly, different permission order" )]
 		[TestCase( "g:r:p,p2", "g:r:p", Description = "Grant first permission" )]
 		[TestCase( "g:r:p,p2", "g:r:p2", Description = "Grant second permission" )]
 		[TestCase( "g:r:*", "g:r:p", Description = "Grant all permissions on exact resource in exact group" )]

--- a/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
@@ -17,6 +17,7 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		[TestCase( "g:r:p", "g:r:p", Description = "Grant exact scope" )]
+		[TestCase( "g:r:p", "g:r:p,p", Description = "Grant exact scope, request same permission multiple times" )]
 		[TestCase( "a:b:c,d", "a:b:c,d", Description = "Grant multiple scope exactly" )]
 		[TestCase( "a:b:c a:b:d", "a:b:c,d", Description = "Grant multiple scope, validate when compressed" )]
 		[TestCase( "a:b:c d:e:f", "d:e:f", Description = "Grant multiple scope uncompressed, validate partial" )]
@@ -25,6 +26,7 @@ namespace D2L.Security.OAuth2.Scopes {
 		[TestCase( "g:r:p,p2", "g:r:p2", Description = "Grant second permission" )]
 		[TestCase( "g:r:*", "g:r:p", Description = "Grant all permissions on exact resource in exact group" )]
 		[TestCase( "g:*:*", "g:r:p", Description = "Grant all permissions on all resources in exact group" )]
+		[TestCase( "g:*:*", "g:r:*,p", Description = "Grant all permission, request redundant permission" )]
 		[TestCase( "*:*:*", "g:r:p", Description = "Grant all permissions on all resources in all groups" )]
 		[TestCase( "*:*:p", "g:r:p", Description = "Grant exact permission on all resources in all groups" )]
 		[TestCase( "*:r:p", "g:r:p", Description = "Grant exact permission on exact resource in all groups" )]

--- a/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
@@ -59,11 +59,9 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		private IEnumerable<Scope> ParseScopePattern( string scopePatterns ) {
-			var scopes = new List<Scope>();
 			foreach( var scopePattern in scopePatterns.Split( ' ' ) ) {
-				scopes.Add( Scope.Parse( scopePattern ) );
+				yield return Scope.Parse( scopePattern );
 			}
-			return scopes;
 		}
 	}
 }


### PR DESCRIPTION
When validating multiple permissions, only the first permission was being validated. See added test with description `Extra permission is not granted` to understand what has been fixed with this change.