### PR TITLE
Add TravisCI badge for Mono build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # D2L.Security.OAuth2
 
-[![Build status](https://ci.appveyor.com/api/projects/status/id5byt9yitcek417/branch/master?svg=true)](https://ci.appveyor.com/project/Brightspace/d2l-security-oauth2/branch/master)
+| Platform   | Build status |
+|------------|--------------|
+| Windows    | [![Windows](https://ci.appveyor.com/api/projects/status/id5byt9yitcek417/branch/master?svg=true)](https://ci.appveyor.com/project/Brightspace/d2l-security-oauth2/branch/master) |
+| Linux+Mono | [![Linux](https://travis-ci.org/Brightspace/D2L.Security.OAuth2.svg?branch=master)](https://travis-ci.org/Brightspace/D2L.Security.OAuth2) |
 
 C# libraries for integrating with Brightspace OAuth 2.0.
 


### PR DESCRIPTION
Not sure if we're going to go this route.

If we do we'd need another job that could combine the two build artifacts into one glorious nupkg and publish it.