### PR TITLE
Changing scope authorizor to be case sensitive.

### DIFF
--- a/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
+++ b/src/D2L.Security.OAuth2/Scopes/ScopeAuthorizer.cs
@@ -41,7 +41,7 @@ namespace D2L.Security.OAuth2.Scopes {
 		}
 
 		private static bool IsMatch( string pattern, string actual ) {
-			return pattern == "*" || String.Equals( pattern, actual, StringComparison.OrdinalIgnoreCase );
+			return pattern == "*" || String.Equals( pattern, actual, StringComparison.Ordinal );
 		}
 
 	}

--- a/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Scopes/ScopeAuthorizerTests.cs
@@ -49,6 +49,9 @@ namespace D2L.Security.OAuth2.Scopes {
 		[TestCase( "*:*:p2", "g:r:p", Description = "Permission does not match - with wildcards" )]
 		[TestCase( "*:r2:*", "g:r:p", Description = "Permission does not match - with wildcards" )]
 		[TestCase( "g2*:*:*", "g:r:p", Description = "Permission does not match - with wildcards" )]
+		[TestCase( "G:r:p", "g:r:p", Description = "Permission does not match (case sensitivity)" )]
+		[TestCase( "g:R:p", "g:r:p", Description = "Permission does not match (case sensitivity)" )]
+		[TestCase( "g:r:P", "g:r:p", Description = "Permission does not match (case sensitivity)" )]
 		public void RequiredScopeIsNotGranted_AuthorizationShouldBeDenied(
 			string grantedScopePattern,
 			string requiredScopePattern ) {


### PR DESCRIPTION
>  The value of the scope parameter is expressed as a list of space-
   delimited, **case-sensitive strings**.
> ~https://tools.ietf.org/html/rfc6749#section-3.3

I can add tests - just want to make sure I'm reading this right / this wasn't an active decision I'm not aware about. 