### PR TITLE
include auth endpoint in token cache keys

### DIFF
--- a/src/D2L.Security.OAuth2.TestFramework/TestAccessTokenProviderFactory.cs
+++ b/src/D2L.Security.OAuth2.TestFramework/TestAccessTokenProviderFactory.cs
@@ -35,11 +35,12 @@ namespace D2L.Security.OAuth2.TestFramework {
 #pragma warning disable 618
 			IPrivateKeyProvider privateKeyProvider = new StaticPrivateKeyProvider( keyId, rsaParameters );
 #pragma warning restore 618
+			Uri authEndpoint = new Uri( tokenProvisioningEndpoint );
 			ITokenSigner tokenSigner = new TokenSigner( privateKeyProvider );
-			IAuthServiceClient authServiceClient = new AuthServiceClient( httpClient, new Uri( tokenProvisioningEndpoint ) );
+			IAuthServiceClient authServiceClient = new AuthServiceClient( httpClient, authEndpoint );
 			INonCachingAccessTokenProvider noCacheTokenProvider = new AccessTokenProvider( tokenSigner, authServiceClient );
 
-			return new CachedAccessTokenProvider( noCacheTokenProvider, Timeout.InfiniteTimeSpan );
+			return new CachedAccessTokenProvider( noCacheTokenProvider, authEndpoint, Timeout.InfiniteTimeSpan );
 		}
 
 	}

--- a/src/D2L.Security.OAuth2/Provisioning/AccessTokenProviderFactory.cs
+++ b/src/D2L.Security.OAuth2/Provisioning/AccessTokenProviderFactory.cs
@@ -29,7 +29,7 @@ namespace D2L.Security.OAuth2.Provisioning {
 			INonCachingAccessTokenProvider accessTokenProvider =
 				new AccessTokenProvider( tokenSigner, authServiceClient );
 
-			return new CachedAccessTokenProvider( accessTokenProvider, tokenRefreshGracePeriod );
+			return new CachedAccessTokenProvider( accessTokenProvider, authEndpoint, tokenRefreshGracePeriod );
 		}
 	}
 }

--- a/src/D2L.Security.OAuth2/Provisioning/Default/CachedAccessTokenProvider.cs
+++ b/src/D2L.Security.OAuth2/Provisioning/Default/CachedAccessTokenProvider.cs
@@ -15,14 +15,17 @@ using System.IdentityModel.Tokens.Jwt;
 namespace D2L.Security.OAuth2.Provisioning.Default {
 	internal sealed class CachedAccessTokenProvider : IAccessTokenProvider {
 		private readonly INonCachingAccessTokenProvider m_accessTokenProvider;
+		private readonly Uri m_authEndpoint;
 		private readonly TimeSpan m_tokenRefreshGracePeriod;
 		private readonly JwtSecurityTokenHandler m_tokenHandler;
 
 		public CachedAccessTokenProvider(
 			INonCachingAccessTokenProvider accessTokenProvider,
+			Uri authEndpoint,
 			TimeSpan tokenRefreshGracePeriod
-    ) {
+		) {
 			m_accessTokenProvider = accessTokenProvider;
+			m_authEndpoint = authEndpoint;
 			m_tokenRefreshGracePeriod = tokenRefreshGracePeriod;
 
 			m_tokenHandler = new JwtSecurityTokenHandler();
@@ -32,7 +35,7 @@ namespace D2L.Security.OAuth2.Provisioning.Default {
 			ClaimSet claimSet,
 			IEnumerable<Scope> scopes,
 			ICache cache
-    ) {
+		) {
 			var @this = this as IAccessTokenProvider;
 			return await @this.ProvisionAccessTokenAsync( claimSet.ToClaims(), scopes, cache ).SafeAsync();
 		}
@@ -41,7 +44,7 @@ namespace D2L.Security.OAuth2.Provisioning.Default {
 			IEnumerable<Claim> claims,
 			IEnumerable<Scope> scopes,
 			ICache cache
-    ) {
+		) {
 			if( cache == null ) {
 				cache = new NullCache();
 			}
@@ -49,7 +52,7 @@ namespace D2L.Security.OAuth2.Provisioning.Default {
 			claims = claims.ToList();
 			scopes = scopes.ToList();
 
-			string cacheKey = TokenCacheKeyBuilder.BuildKey( claims, scopes );
+			string cacheKey = TokenCacheKeyBuilder.BuildKey( m_authEndpoint, claims, scopes );
 
 			CacheResponse cacheResponse = await cache.GetAsync( cacheKey ).SafeAsync();
 

--- a/src/D2L.Security.OAuth2/Provisioning/TokenCacheKeyBuilder.cs
+++ b/src/D2L.Security.OAuth2/Provisioning/TokenCacheKeyBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using D2L.Security.OAuth2.Scopes;
@@ -7,6 +8,7 @@ using Newtonsoft.Json;
 namespace D2L.Security.OAuth2.Provisioning {
 	internal static class TokenCacheKeyBuilder {
 		internal static string BuildKey(
+			Uri authEndpoint,
 			IEnumerable<Claim> claims,
 			IEnumerable<Scope> scopes
 		) {
@@ -17,6 +19,7 @@ namespace D2L.Security.OAuth2.Provisioning {
 			IOrderedEnumerable<Scope> sortedScopes = scopes.OrderBy( s => s.ToString() );
 
 			var keyObject = new {
+				issuer = authEndpoint.AbsoluteUri,
 				claims = sortedClaims.Select( c => new { name = c.Type, value = c.Value } ),
 				scopes = sortedScopes.Select( s => s.ToString() )
 			};

--- a/test/D2L.Security.OAuth2.UnitTests/Provisioning/CachedAccessTokenProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Provisioning/CachedAccessTokenProviderTests.cs
@@ -123,7 +123,7 @@ namespace D2L.Security.OAuth2.Provisioning {
 		[Test]
 		public async Task ProvisionAccessTokenAsync_CallPassThroughOverload_CallsOtherOverload() {
 
-			const string key = "{\"claims\":[{\"name\":\"iss\",\"value\":\"TheIssuer\"}],\"scopes\":[]}";
+			const string key = "{\"issuer\":\"https://example.com/\",\"claims\":[{\"name\":\"iss\",\"value\":\"TheIssuer\"}],\"scopes\":[]}";
 
 			m_serviceTokenCacheMock.Setup( x => x.GetAsync( key ) )
 				.Returns( Task.FromResult( new CacheResponse( true, BuildTestToken() ) ) );
@@ -139,6 +139,7 @@ namespace D2L.Security.OAuth2.Provisioning {
 		private IAccessTokenProvider GetCachedAccessTokenProvider( int tokenRefreshGracePeriod = 120 ) {
 			return new CachedAccessTokenProvider(
 				m_accessTokenProviderMock.Object,
+				new Uri( "https://example.com" ),
 				TimeSpan.FromSeconds( tokenRefreshGracePeriod )
 				);
 		}

--- a/test/D2L.Security.OAuth2.UnitTests/Provisioning/TokenCacheKeyBuilderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Provisioning/TokenCacheKeyBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Security.Claims;
 using D2L.Security.OAuth2.Scopes;
 using NUnit.Framework;
@@ -8,8 +9,8 @@ namespace D2L.Security.OAuth2.Provisioning {
 	internal sealed class TokenCacheKeyBuilderTests {
 		[Test]
 		public void BuildKey_EmptyClaimsAndScopes_MatchesExpected() {
-			string key = TokenCacheKeyBuilder.BuildKey( Enumerable.Empty<Claim>(), Enumerable.Empty<Scope>() );
-			Assert.AreEqual( "{\"claims\":[],\"scopes\":[]}", key );
+			string key = TokenCacheKeyBuilder.BuildKey( new Uri( "https://example.com" ), Enumerable.Empty<Claim>(), Enumerable.Empty<Scope>() );
+			Assert.AreEqual( "{\"issuer\":\"https://example.com/\",\"claims\":[],\"scopes\":[]}", key );
 		}
 
 		[Test]
@@ -18,8 +19,16 @@ namespace D2L.Security.OAuth2.Provisioning {
 			Claim[] claims = { new Claim( "xyz", "val3" ), new Claim( "abc", "val1" ), new Claim( "mno", "val2" ) };
 			Scope[] scopes = { new Scope( "x", "y", "z" ), new Scope( "a", "b", "c" ), new Scope( "m", "n", "o" ) };
 
-			string key = TokenCacheKeyBuilder.BuildKey( claims, scopes );
-			Assert.AreEqual( "{\"claims\":[{\"name\":\"abc\",\"value\":\"val1\"},{\"name\":\"mno\",\"value\":\"val2\"},{\"name\":\"xyz\",\"value\":\"val3\"}],\"scopes\":[\"a:b:c\",\"m:n:o\",\"x:y:z\"]}", key );
+			string key = TokenCacheKeyBuilder.BuildKey( new Uri( "https://example.com" ), claims, scopes );
+			Assert.AreEqual( "{\"issuer\":\"https://example.com/\",\"claims\":[{\"name\":\"abc\",\"value\":\"val1\"},{\"name\":\"mno\",\"value\":\"val2\"},{\"name\":\"xyz\",\"value\":\"val3\"}],\"scopes\":[\"a:b:c\",\"m:n:o\",\"x:y:z\"]}", key );
+		}
+
+		[Test]
+		public void BuildKey_DifferentEndpoint_SameClaimsAndScopes_AreDifferent() {
+			string key1 = TokenCacheKeyBuilder.BuildKey( new Uri( "https://example.com/a" ), Enumerable.Empty<Claim>(), Enumerable.Empty<Scope>() );
+			string key2 = TokenCacheKeyBuilder.BuildKey( new Uri( "https://example.com/b" ), Enumerable.Empty<Claim>(), Enumerable.Empty<Scope>() );
+
+			Assert.AreNotEqual( key1, key2 );
 		}
 	}
 }


### PR DESCRIPTION
Ideally the "aud" claim or something would change and thus this would've been accounted for, but oh well.

Anyway, this isn't really an issue in production, but i've had a team member run into it a few times now.

1. Have LMS configured against Auth Service A
2. Request token
3. Reconfigure LMS against Auth Service B
4. Request token
5. Notice that you were given a cached token from Auth Service A

Currently requires an app pool and/or service manager restart to clear the in-memory cache.