### PR TITLE
Add support for bare JWK to IJwkProvider

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/Default/Data/IJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/IJwksProvider.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	internal interface IJwksProvider {
 		Task<JsonWebKeySet> RequestJwksAsync();
+		Task<JsonWebKey> RequestJwkAsync( Guid keyId );
 		string Namespace { get; }
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using D2L.Security.OAuth2.Validation.Exceptions;
@@ -6,60 +7,112 @@ using D2L.Services;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	internal sealed class JwksProvider : IJwksProvider {
-
-		private const string JWKS_PATH = ".well-known/jwks";
-
 		private readonly HttpClient m_httpClient;
-		private readonly Uri m_jwksEndpoint;
+		private readonly Uri m_authEndpoint;
 
 		public JwksProvider(
 			HttpClient httpClient,
 			Uri authEndpoint
 		) {
 			m_httpClient = httpClient;
-			m_jwksEndpoint = BuildJwksEndpoint( authEndpoint );
+			m_authEndpoint = authEndpoint;
 		}
 		
 		async Task<JsonWebKeySet> IJwksProvider.RequestJwksAsync() {
+			var url = GetJwksEndpoint( m_authEndpoint );
+
 			try {
-				using( HttpResponseMessage response = await m_httpClient.GetAsync( m_jwksEndpoint ).SafeAsync() ) {
+				using( HttpResponseMessage response = await m_httpClient.GetAsync( url ).SafeAsync() ) {
 					response.EnsureSuccessStatusCode();
 					string jsonResponse = await response.Content.ReadAsStringAsync().SafeAsync();
-					var jwks = new JsonWebKeySet( jsonResponse, m_jwksEndpoint );
+					var jwks = new JsonWebKeySet( jsonResponse, url );
 					return jwks;
 				}
 			} catch( HttpRequestException e ) {
-				throw CreateException( e );
+				throw CreateException( e, url );
 			} catch( JsonWebKeyParseException e ) {
-				throw CreateException( e );
+				throw CreateException( e, url );
 			}
 		}
 
-		string IJwksProvider.Namespace {
-			get {
-				return m_jwksEndpoint.AbsoluteUri;
+		async Task<JsonWebKey> IJwksProvider.RequestJwkAsync( Guid keyId ) {
+			var url = GetJwkEndpoint( m_authEndpoint, keyId );
+			try {
+				using( var res = await m_httpClient.GetAsync( url ) ) {
+					// This is temporary while we try to fully deprecate the
+					// JWKS route. 404 might mean the key doesn't exist (which
+					// will make the call to jwks likely return 200 but still
+					// result in no key - that's fine but slow) or the jwk
+					// route isn't supported which will make this recover (but
+					// slowely.) Where it matters (the LMS and auth) JWK is
+					// supported so this shouldn't be necessary. We don't
+					// expect many "legitimate" 404s (keys that don't exist.)
+					// so in practice this should only happen when it's
+					// actually important, if it ever happens.
+					if( res.StatusCode == HttpStatusCode.NotFound ) {
+						return await FallbackToJwks( keyId );
+					}
+
+					res.EnsureSuccessStatusCode();
+
+					string json = await res.Content
+						.ReadAsStringAsync()
+						.SafeAsync();
+
+					return JsonWebKey.FromJson( json);
+				}
+			} catch( HttpRequestException e ) {
+				throw CreateException( e, url );
+			} catch( JsonWebKeyParseException e ) {
+				throw CreateException( e, url );
 			}
 		}
 
-		private Exception CreateException( Exception e ) {
-			string message = string.Format(
-				"Error while looking up JWKS at {0}: {1}",
-				m_jwksEndpoint,
-				e.Message
-			);
+		private async Task<JsonWebKey> FallbackToJwks( Guid keyId ) {
+			var allKeys = await ( this as IJwksProvider ).RequestJwksAsync();
+
+			JsonWebKey theKey;
+
+			if( !allKeys.TryGetKey( keyId, out theKey ) ) {
+				throw new PublicKeyLookupFailureException(
+					$"couldn't find public key {keyId} after falling back to jwks route"
+				);
+			}
+
+			return theKey;
+		}
+
+		string IJwksProvider.Namespace => m_authEndpoint.AbsoluteUri;
+
+		private Exception CreateException( Exception e, Uri endpoint ) {
+			string message = $"Error while looking up key(s) at {endpoint}: {e.Message}";
 
 			return new PublicKeyLookupFailureException( message, e );
 		}
 
-		private static Uri BuildJwksEndpoint( Uri authEndpoint ) {
-			string authRoot = authEndpoint.ToString();
-			if( !authRoot.EndsWith( "/" ) ) {
-				authRoot += "/";
-			}
+		private static Uri GetJwkEndpoint( Uri authEndpoint, Guid keyId ) {
+			string authRoot = MakeSureThereIsATrailingSlash( authEndpoint );
 
-			authRoot += JWKS_PATH;
+			authRoot += $"jwk/{keyId}";
 
 			return new Uri( authRoot );
+		}
+
+		private static Uri GetJwksEndpoint( Uri authEndpoint ) {
+			string authRoot = MakeSureThereIsATrailingSlash( authEndpoint );
+
+			authRoot += ".well-known/jwks";
+
+			return new Uri( authRoot );
+		}
+
+		private static string MakeSureThereIsATrailingSlash( Uri uri ) {
+			string root = uri.ToString();
+			if ( root[root.Length - 1 ] == '/') {
+				return root;
+			}
+
+			return root + '/';
 		}
 	}
 }

--- a/src/D2L.Security.OAuth2/Validation/Exceptions/PublicKeyLookupFailureException.cs
+++ b/src/D2L.Security.OAuth2/Validation/Exceptions/PublicKeyLookupFailureException.cs
@@ -12,5 +12,11 @@ namespace D2L.Security.OAuth2.Validation.Exceptions {
 		/// </summary>
 		public PublicKeyLookupFailureException( string message, Exception inner )
 			: base( message, inner ) {}
+
+		/// <summary>
+		/// Constructs a new <see cref="PublicKeyLookupFailureException"/>
+		/// </summary>
+		public PublicKeyLookupFailureException( string message )
+			: base( message ) {}
 	}
 }


### PR DESCRIPTION
This adds a new method IJwkProvider.RequestJwkAsync. It falls back to
RequestJwksAsync on 404. We want to move to JWK to support better
caching (i.e. performance) and it is more compatible with services
like S3+CF that would increase our fault-tolerance.