### PR TITLE
Marking up ID2LPrincipal, IAccessToken for immutability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 obj
 packages
 docs/output
+.vs
 *.suo
 *.user
 *.nupkg

--- a/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.csproj
+++ b/src/D2L.Security.OAuth2.WebApi/D2L.Security.OAuth2.WebApi.csproj
@@ -37,6 +37,9 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="D2L.CodeStyle.Annotations, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\D2L.CodeStyle.Annotations.0.17.0\lib\net20\D2L.CodeStyle.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="D2L.Services.Core.Extensions, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\D2L.Services.Core.Extensions.1.1.1.0\lib\net451\D2L.Services.Core.Extensions.dll</HintPath>
       <Private>True</Private>

--- a/src/D2L.Security.OAuth2.WebApi/Principal/D2LPrincipalToIPrincipalAdaptor.cs
+++ b/src/D2L.Security.OAuth2.WebApi/Principal/D2LPrincipalToIPrincipalAdaptor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Security.Principal;
+using D2L.CodeStyle.Annotations;
 using D2L.Security.OAuth2.Scopes;
 using D2L.Security.OAuth2.Validation.AccessTokens;
 
@@ -10,6 +11,7 @@ namespace D2L.Security.OAuth2.Principal {
 	/// </summary>
 	internal sealed class D2LPrincipalToIPrincipalAdaptor : IPrincipal, ID2LPrincipal {
 		private readonly ID2LPrincipal m_principal;
+		[Mutability.Audited("Todd Lang", "02-Mar-2018", ".Net class can't modify, but is immutable.")]
 		private readonly IIdentity m_identity;
 
 		public D2LPrincipalToIPrincipalAdaptor( ID2LPrincipal principal ) {

--- a/src/D2L.Security.OAuth2.WebApi/packages.config
+++ b/src/D2L.Security.OAuth2.WebApi/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="D2L.CodeStyle.Analyzers" version="0.36.0" targetFramework="net461" developmentOnlyDependency="true" />
+  <package id="D2L.CodeStyle.Annotations" version="0.17.0" targetFramework="net461" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
@@ -7,5 +9,4 @@
   <package id="SimpleLogInterface" version="1.0.2.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.1" targetFramework="net451" />
-  <package id="D2L.CodeStyle.Analyzers" version="0.36.0" targetFramework="net461" developmentOnlyDependency="true" />
 </packages>

--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -39,8 +39,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="D2L.CodeStyle.Annotations, Version=0.16.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\D2L.CodeStyle.Annotations.0.16.0\lib\net20\D2L.CodeStyle.Annotations.dll</HintPath>
+    <Reference Include="D2L.CodeStyle.Annotations, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\D2L.CodeStyle.Annotations.0.17.0\lib\net20\D2L.CodeStyle.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="D2L.Services.Core.Exceptions">
       <HintPath>..\..\packages\D2L.Services.Core.Exceptions.1.0.0.27289\lib\net451\D2L.Services.Core.Exceptions.dll</HintPath>

--- a/src/D2L.Security.OAuth2/Principal/D2LPrincipal.cs
+++ b/src/D2L.Security.OAuth2/Principal/D2LPrincipal.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using D2L.Services;
 using D2L.Security.OAuth2.Scopes;
 using D2L.Security.OAuth2.Validation.AccessTokens;
 
@@ -16,19 +15,19 @@ namespace D2L.Security.OAuth2.Principal {
 
 		private readonly Lazy<Guid> m_tenantId;
 		private readonly PrincipalType m_principalType;
-		private readonly Lazy<List<Scope>> m_scopes;
+		private readonly Lazy<IEnumerable<Scope>> m_scopes;
 
 		public D2LPrincipal( IAccessToken accessToken ) {
 			m_accessToken = accessToken;
 
 			m_tenantId = new Lazy<Guid>( GetTenantId );
 
-			m_scopes = new Lazy<List<Scope>>(
+			m_scopes = new Lazy<IEnumerable<Scope>>(
 				() => m_accessToken.GetScopes().ToList()
 			);
 
 			long userId;
-			if ( !m_accessToken.TryGetUserId( out userId ) ) {
+			if( !m_accessToken.TryGetUserId( out userId ) ) {
 				m_principalType = PrincipalType.Service;
 				return;
 			}
@@ -36,7 +35,7 @@ namespace D2L.Security.OAuth2.Principal {
 			m_userId = userId;
 
 			long actualUserId;
-			if ( !m_accessToken.TryGetActualUserId( out actualUserId ) ) {
+			if( !m_accessToken.TryGetActualUserId( out actualUserId ) ) {
 				// Doing this means that code that wants to ignore
 				// impersonation can do so with less branching.
 				m_actualUserId = userId;
@@ -77,7 +76,7 @@ namespace D2L.Security.OAuth2.Principal {
 		IAccessToken ID2LPrincipal.AccessToken {
 			get { return m_accessToken; }
 		}
-		
+
 		private Guid GetTenantId() {
 			string strTenantId = m_accessToken.GetTenantId();
 
@@ -90,7 +89,7 @@ namespace D2L.Security.OAuth2.Principal {
 		}
 
 		private void AssertPrincipalTypeForClaim( PrincipalType type, string claimName ) {
-			if ( m_principalType != type ) {
+			if( m_principalType != type ) {
 				string message = string.Format(
 					"Cannot access {0} for principal type: {1}",
 					claimName,

--- a/src/D2L.Security.OAuth2/Principal/ID2LPrincipal.cs
+++ b/src/D2L.Security.OAuth2/Principal/ID2LPrincipal.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using D2L.Security.OAuth2.Scopes;
 using D2L.Security.OAuth2.Validation.AccessTokens;
+using static D2L.CodeStyle.Annotations.Objects;
 
 namespace D2L.Security.OAuth2.Principal {
 	/// <summary>
 	/// Principal class that is D2L-specific
 	/// </summary>
+	[Immutable]
 	public interface ID2LPrincipal {
 		/// <summary>
 		/// Only valid if the <see cref="Type"/> is User

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessToken.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessToken.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.Security.Claims;
+using D2L.CodeStyle.Annotations;
 
 #if DNXCORE50
 using System.IdentityModel.Tokens.Jwt;
@@ -9,6 +10,7 @@ using System.IdentityModel.Tokens.Jwt;
 
 namespace D2L.Security.OAuth2.Validation.AccessTokens {
 	internal sealed class AccessToken : IAccessToken {
+		[Mutability.Audited("Todd Lang", "02-Mar-2018", ".Net class we can't modify, but is used immutably.")]
 		private readonly JwtSecurityToken m_inner;
 		private readonly IAccessToken m_this;
 

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/IAccessToken.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/IAccessToken.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using static D2L.CodeStyle.Annotations.Objects;
 
 namespace D2L.Security.OAuth2.Validation.AccessTokens {
 
 	/// <summary>
 	/// A strongly-typed version of the access token
 	/// </summary>
+	[Immutable]
 	public interface IAccessToken {
 
 		/// <summary>
@@ -18,7 +20,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 		/// The raw, signed access token. Treat it like a password (for example, do not log).
 		/// </summary>
 		string SensitiveRawAccessToken { get; }
-		
+
 		/// <summary>
 		/// Claims associated with this token
 		/// </summary>

--- a/src/D2L.Security.OAuth2/packages.config
+++ b/src/D2L.Security.OAuth2/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="D2L.CodeStyle.Analyzers" version="0.36.0" targetFramework="net461" developmentOnlyDependency="true" />
-  <package id="D2L.CodeStyle.Annotations" version="0.16.0" targetFramework="net461" />
+  <package id="D2L.CodeStyle.Annotations" version="0.17.0" targetFramework="net461" />
   <package id="D2L.Services.Core.Exceptions" version="1.0.0.27289" targetFramework="net451" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />

--- a/test/D2L.Security.OAuth2.WebApi.IntegrationTests/app.config
+++ b/test/D2L.Security.OAuth2.WebApi.IntegrationTests/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>


### PR DESCRIPTION
-Updating D2L packages to latest version

It was required to update the packages because the Mutability.Audited attribute only existed in the newer versions of the CodeAnnotations.  In order to ensure sensible operation, I snapped up all the D2L packages together.