### PR TITLE
Omsmith/jwks fallback all errors

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
@@ -49,7 +49,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 					// expect many "legitimate" 404s (keys that don't exist.)
 					// so in practice this should only happen when it's
 					// actually important, if it ever happens.
-					if( res.StatusCode == HttpStatusCode.NotFound ) {
+					if( res.StatusCode != HttpStatusCode.OK ) {
 						return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
 					}
 

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
@@ -164,5 +164,27 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
 			}
 		}
+
+		[Test]
+		public async Task RequestJwkAsync_500_Fallback_Success() {
+			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new JwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
 	}
 }

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
@@ -20,9 +20,12 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		private static string GOOD_JWK = @"{""kid"":""" + GOOD_JWK_ID + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
 		private static string GOOD_JSON = @"{""keys"": [" + GOOD_JWK + "]}";
 		private static string HTML = "<html><body><p>This isn't JSON eh</p></body></html>";
+		private static string GOOD_JWK_PATH = GOOD_PATH + "/jwk/" + GOOD_JWK_ID;
 
 		private IHttpServer SetupJwkServer(
-			out string host
+			out string host,
+			bool hasJwk = true,
+			HttpStatusCode jwkStatusCode = HttpStatusCode.OK
 		) {
 			IHttpServer jwksServer = HttpMockFactory.Create( out host );
 			
@@ -37,6 +40,11 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 			jwksServer.Stub(
 				x => x.Get( HTML_PATH + JWKS_PATH )
 			).Return( HTML ).WithStatus( HttpStatusCode.OK );
+
+			jwksServer
+				.Stub( x => x.Get( GOOD_JWK_PATH ) )
+				.Return( hasJwk ? GOOD_JWK : "" )
+				.WithStatus( jwkStatusCode );
 
 			return jwksServer;
 		}
@@ -110,6 +118,50 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 					.RequestJwksAsync()
 					.SafeAsync();
 				} );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_Success() {
+			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new JwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasNotCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_404_Fallback_Success() {
+			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound  ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new JwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
 			}
 		}
 	}

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
@@ -43,9 +43,10 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		[Test]
 		public async Task SuccessCase() {
-			using( SetupJwkServer( out string host ) ) {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
 				IJwksProvider publicKeyProvider = new JwksProvider(
-					new HttpClient(),
+					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
 
@@ -61,9 +62,10 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		[Test]
 		public void RequestJwksAsync_HTML_Throws() {
-			using( SetupJwkServer( out string host ) ) {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
 				IJwksProvider publicKeyProvider = new JwksProvider(
-					new HttpClient(),
+					httpClient,
 					new Uri( host + HTML_PATH )
 				);
 
@@ -79,9 +81,10 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		[Test]
 		public void RequestJwksAsync_404_Throws() {
-			using( SetupJwkServer( out string host ) ) {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
 				IJwksProvider publicKeyProvider = new JwksProvider(
-					new HttpClient(),
+					httpClient,
 					new Uri( host + BAD_PATH )
 				);
 
@@ -95,9 +98,10 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		[Test]
 		public void RequestJwksAsync_CantReachServer_Throws() {
-			using( SetupJwkServer( out string host ) ) {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
 				IJwksProvider publicKeyProvider = new JwksProvider(
-					new HttpClient(),
+					httpClient,
 					new Uri( "http://foo.bar.fakesite.isurehopethisisneveravalidTLD" )
 				);
 


### PR DESCRIPTION
BDP's S3 bucket doesn't yet provide `/jwk/:id` and 403s on unknown s3 keys.