### PR TITLE
Remove fallback to jwks when fetching jwk

### DIFF
--- a/src/D2L.Security.OAuth2.TestFramework/AuthServiceMock.cs
+++ b/src/D2L.Security.OAuth2.TestFramework/AuthServiceMock.cs
@@ -94,7 +94,7 @@ namespace D2L.Security.OAuth2.TestFramework {
 				keyDtos.Add( dto );
 
 				m_server
-					.Stub( r => r.Get( $"jwk/{ key.Id }" ) )
+					.Stub( r => r.Get( $"/jwk/{ key.Id }" ) )
 					.Return( JsonConvert.SerializeObject( dto ) )
 					.OK();
 			}

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
@@ -39,18 +39,8 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 			var url = GetJwkEndpoint( m_authEndpoint, keyId );
 			try {
 				using( var res = await m_httpClient.GetAsync( url ).SafeAsync() ) {
-					// This is temporary while we try to fully deprecate the
-					// JWKS route. 404 might mean the key doesn't exist (which
-					// will make the call to jwks likely return 200 but still
-					// result in no key - that's fine but slow) or the jwk
-					// route isn't supported which will make this recover (but
-					// slowely.) Where it matters (the LMS and auth) JWK is
-					// supported so this shouldn't be necessary. We don't
-					// expect many "legitimate" 404s (keys that don't exist.)
-					// so in practice this should only happen when it's
-					// actually important, if it ever happens.
-					if( res.StatusCode != HttpStatusCode.OK ) {
-						return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
+					if ( res.StatusCode == HttpStatusCode.NotFound ) {
+						return JsonWebKeySet.Empty( url );
 					}
 
 					res.EnsureSuccessStatusCode();

--- a/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
@@ -42,7 +42,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		private JsonWebKeySet( ImmutableArray<JsonWebKey> keys, Uri src ) {
 			m_keys = keys;
-			Source = src ?? throw new NotImplementedException( nameof( src ) );
+			Source = src ?? throw new ArgumentNullException( nameof( src ) );
 		}
 
 		internal static JsonWebKeySet Empty( Uri src ) {

--- a/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
@@ -34,9 +34,19 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		}
 
-		internal JsonWebKeySet( JsonWebKey jsonWebKey, Uri src ) {
-			Source = src;
-			m_keys = ImmutableArray.Create( jsonWebKey );
+		internal JsonWebKeySet( JsonWebKey jsonWebKey, Uri src )
+			: this(
+				ImmutableArray.Create( jsonWebKey ),
+				src
+			) { }
+
+		private JsonWebKeySet( ImmutableArray<JsonWebKey> keys, Uri src ) {
+			m_keys = keys;
+			Source = src ?? throw new NotImplementedException( nameof( src ) );
+		}
+
+		internal static JsonWebKeySet Empty( Uri src ) {
+			return new JsonWebKeySet( ImmutableArray<JsonWebKey>.Empty, src );
 		}
 
 		public bool TryGetKey( Guid keyId, out JsonWebKey key ) {

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/JwksProviderTests.cs
@@ -141,49 +141,5 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
 			}
 		}
-
-		[Test]
-		public async Task RequestJwkAsync_404_Fallback_Success() {
-			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound ) )
-			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
-					httpClient,
-					new Uri( host + GOOD_PATH )
-				);
-
-				JsonWebKeySet jwks = await jwksProvider
-					.RequestJwkAsync( GOOD_JWK_ID )
-					.SafeAsync();
-				Assert.IsNotNull( jwks );
-
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
-
-				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
-				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
-			}
-		}
-
-		[Test]
-		public async Task RequestJwkAsync_500_Fallback_Success() {
-			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
-			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
-					httpClient,
-					new Uri( host + GOOD_PATH )
-				);
-
-				JsonWebKeySet jwks = await jwksProvider
-					.RequestJwkAsync( GOOD_JWK_ID )
-					.SafeAsync();
-				Assert.IsNotNull( jwks );
-
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
-
-				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
-				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
-			}
-		}
 	}
 }

--- a/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.EcDsa.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.EcDsa.cs
@@ -8,6 +8,7 @@ using D2L.Security.OAuth2.TestFramework;
 using D2L.Security.OAuth2.TestFrameworks;
 using D2L.Security.OAuth2.Validation.Exceptions;
 using D2L.Services;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace D2L.Security.OAuth2.Validation.AccessTokens {
@@ -113,10 +114,13 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			public void ValidateAsync_GoodSignature_Succeeds_WebCrypto( string jwk, string token ) {
 				var mockServer = HttpMockFactory.Create( out string host );
 
+				var keyId = (string)JsonConvert.DeserializeObject<Dictionary<string, object>>( jwk )["kid"];
+
 				mockServer
-					.Stub( r => r.Get( "/.well-known/jwks" ) )
-					.Return( @"{""keys"":[" + jwk + "]}" )
+					.Stub( r => r.Get( $"/jwk/{keyId}" ) )
+					.Return( jwk )
 					.OK();
+
 
 				// We expect these to be expired because they are static
 				// The rest of the validation should have otherwise proceeded swimmingly


### PR DESCRIPTION
* Everyone supports JWK
* The fallback can cause perf issues due to the response size of jwks, its uncachability and a bug with one of the public key hosts in the system
* Let's keep everyone supporting jwk