### PR TITLE
Add a standard JWKS provider for 3rd party support

### DIFF
--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -83,6 +83,7 @@
       <DependentUpon>D2LSecurityToken.cs</DependentUpon>
     </Compile>
     <Compile Include="Keys\Default\D2LSecurityTokenFactory.cs" />
+    <Compile Include="Keys\Default\Data\StandardJwksProvider.cs" />
     <Compile Include="Keys\Default\EcDsaJsonWebKey.cs" />
     <Compile Include="Keys\Default\EcDsaJsonWebKey.ECCPublicKeyBlobFormatter.cs">
       <DependentUpon>EcDsaJsonWebKey.cs</DependentUpon>
@@ -124,7 +125,7 @@
     <Compile Include="Keys\Default\IPrivateKeyProvider.cs" />
     <Compile Include="Keys\Default\IPublicKeyProvider.cs" />
     <Compile Include="Keys\Default\Data\IJwksProvider.cs" />
-    <Compile Include="Keys\Default\Data\JwksProvider.cs" />
+    <Compile Include="Keys\Default\Data\D2LJwksProvider.cs" />
     <Compile Include="Keys\RsaTokenSignerFactory.cs" />
     <Compile Include="Keys\TokenSignerFactory.cs" />
     <Compile Include="Keys\UnsignedToken.cs" />

--- a/src/D2L.Security.OAuth2/Keys/Caching/IInMemoryPublicKeyCache.cs
+++ b/src/D2L.Security.OAuth2/Keys/Caching/IInMemoryPublicKeyCache.cs
@@ -5,7 +5,7 @@ namespace D2L.Security.OAuth2.Keys.Caching {
 	internal interface IInMemoryPublicKeyCache {
 
 		void Set( string srcNamespace, D2LSecurityToken key );
-		D2LSecurityToken Get( string srcNamespace, Guid keyId );
+		D2LSecurityToken Get( string srcNamespace, string keyId );
 
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/Caching/InMemoryPublicKeyCache.cs
+++ b/src/D2L.Security.OAuth2/Keys/Caching/InMemoryPublicKeyCache.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 #if !DNXCORE50
 using System.Runtime.Caching;
@@ -37,12 +37,12 @@ namespace D2L.Security.OAuth2.Keys.Caching {
 			);
 		}
 
-		D2LSecurityToken IInMemoryPublicKeyCache.Get( string srcNamespace, Guid keyId ) {
+		D2LSecurityToken IInMemoryPublicKeyCache.Get( string srcNamespace, string keyId ) {
 			var result = m_cache.Get( BuildCacheKey( srcNamespace, keyId ) ) as D2LSecurityToken;
 			return result;
 		}
 
-		private static string BuildCacheKey( string srcNamespace, Guid keyId ) {
+		private static string BuildCacheKey( string srcNamespace, string keyId ) {
 			string result = string.Format( CACHE_KEY_PATTERN, srcNamespace, keyId );
 			return result;
 		}

--- a/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityToken.SecurityToken.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityToken.SecurityToken.cs
@@ -6,7 +6,7 @@ using System.IdentityModel.Tokens;
 namespace D2L.Security.OAuth2.Keys.Default {
 	internal partial class D2LSecurityToken : SecurityToken {
 
-		public override string Id { get { return KeyId.ToString(); } }
+		public override string Id { get { return KeyId; } }
 
 		public override ReadOnlyCollection<SecurityKey> SecurityKeys {
 			get {
@@ -34,7 +34,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			var clause = keyIdentifierClause as NamedKeySecurityKeyIdentifierClause;
 			return clause != null
 				&& clause.Name.Equals( OAuth2.Constants.Claims.KEY_ID, StringComparison.Ordinal )
-				&& clause.Id.Equals( KeyId.ToString(), StringComparison.OrdinalIgnoreCase );
+				&& clause.Id.Equals( KeyId, StringComparison.OrdinalIgnoreCase );
 		}
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityToken.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityToken.cs
@@ -7,7 +7,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 	internal sealed partial class D2LSecurityToken : SecurityToken {
 
-		private Guid m_id;
+		private string m_id;
 		private readonly DateTime m_validFrom;
 		private readonly DateTime m_validTo;
 
@@ -18,7 +18,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		private readonly ThreadLocal<Tuple<AsymmetricSecurityKey, IDisposable>> m_key;
 
 		public D2LSecurityToken(
-			Guid id,
+			string id,
 			DateTime validFrom,
 			DateTime validTo,
 			Func<Tuple<AsymmetricSecurityKey, IDisposable>> keyFactory
@@ -37,7 +37,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			);
 		}
 
-		public Guid KeyId { get { return m_id; } }
+		public string KeyId { get { return m_id; } }
 
 		public override DateTime ValidFrom {
 			get { return m_validFrom; }

--- a/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityTokenFactory.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/D2LSecurityTokenFactory.cs
@@ -19,7 +19,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		D2LSecurityToken ID2LSecurityTokenFactory.Create(
 			Func<Tuple<AsymmetricSecurityKey, IDisposable>> keyFactory
 		) {
-			Guid id = Guid.NewGuid();
+			string id = Guid.NewGuid().ToString();
 			DateTime validFrom = m_dateTimeProvider.UtcNow;
 			DateTime validTo = validFrom + m_keyLifetime;
 

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/D2LJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/D2LJwksProvider.cs
@@ -2,15 +2,16 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web;
 using D2L.Security.OAuth2.Validation.Exceptions;
 using D2L.Services;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
-	internal sealed class JwksProvider : IJwksProvider {
+	internal sealed class D2LJwksProvider : IJwksProvider {
 		private readonly HttpClient m_httpClient;
 		private readonly Uri m_authEndpoint;
 
-		public JwksProvider(
+		public D2LJwksProvider(
 			HttpClient httpClient,
 			Uri authEndpoint
 		) {
@@ -35,7 +36,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 			}
 		}
 
-		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( Guid keyId ) {
+		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( string keyId ) {
 			var url = GetJwkEndpoint( m_authEndpoint, keyId );
 			try {
 				using( var res = await m_httpClient.GetAsync( url ).SafeAsync() ) {
@@ -77,10 +78,10 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 			return new PublicKeyLookupFailureException( message, e );
 		}
 
-		private static Uri GetJwkEndpoint( Uri authEndpoint, Guid keyId ) {
+		private static Uri GetJwkEndpoint( Uri authEndpoint, string keyId ) {
 			string authRoot = MakeSureThereIsATrailingSlash( authEndpoint );
 
-			authRoot += $"jwk/{keyId}";
+			authRoot += $"jwk/{HttpUtility.UrlEncode( keyId )}";
 
 			return new Uri( authRoot );
 		}
@@ -95,7 +96,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		private static string MakeSureThereIsATrailingSlash( Uri uri ) {
 			string root = uri.ToString();
-			if( root[ root.Length - 1 ] == '/' ) {
+			if( root[root.Length - 1] == '/' ) {
 				return root;
 			}
 

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/IJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/IJwksProvider.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	internal interface IJwksProvider {
 		Task<JsonWebKeySet> RequestJwksAsync();
-		Task<JsonWebKeySet> RequestJwkAsync( Guid keyId );
+		Task<JsonWebKeySet> RequestJwkAsync( string keyId );
 		string Namespace { get; }
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/StandardJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/StandardJwksProvider.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using D2L.Security.OAuth2.Validation.Exceptions;
+using D2L.Services;
+
+namespace D2L.Security.OAuth2.Keys.Default.Data {
+	class StandardJwksProvider : IJwksProvider {
+		private readonly HttpClient m_httpClient;
+		private readonly Uri m_authEndpoint;
+
+		public StandardJwksProvider(
+			HttpClient httpClient,
+			Uri authEndpoint
+		) {
+			m_httpClient = httpClient;
+			m_authEndpoint = authEndpoint;
+		}
+
+		string IJwksProvider.Namespace => m_authEndpoint.AbsoluteUri;
+
+		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( string keyId ) {
+			try {
+				return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
+			} catch( HttpRequestException e ) {
+				throw CreateException( e, m_authEndpoint );
+			} catch( JsonWebKeyParseException e ) {
+				throw CreateException( e, m_authEndpoint );
+			}
+		}
+
+		async Task<JsonWebKeySet> IJwksProvider.RequestJwksAsync() {
+			try {
+				using( HttpResponseMessage response = await m_httpClient.GetAsync( m_authEndpoint ).SafeAsync() ) {
+					response.EnsureSuccessStatusCode();
+					string jsonResponse = await response.Content.ReadAsStringAsync().SafeAsync();
+					var jwks = new JsonWebKeySet( jsonResponse, m_authEndpoint );
+					return jwks;
+				}
+			} catch( HttpRequestException e ) {
+				throw CreateException( e, m_authEndpoint );
+			} catch( JsonWebKeyParseException e ) {
+				throw CreateException( e, m_authEndpoint );
+			}
+		}
+
+		private Exception CreateException( Exception e, Uri endpoint ) {
+			string message = $"Error while looking up key(s) at {endpoint}: {e.Message}";
+
+			return new PublicKeyLookupFailureException( message, e );
+		}
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/Default/EcDsaJsonWebKey.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/EcDsaJsonWebKey.cs
@@ -21,7 +21,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// <param name="expiresAt">When the key expires</param>
 		/// <param name="publicBlob">Blob in <see cref="CngKeyBlobFormat.EccPublicBlob"/> format</param>
 		public EcDsaJsonWebKey(
-			Guid id,
+			string id,
 			DateTime? expiresAt,
 			byte[] publicBlob
 		) : base( id, expiresAt ) {
@@ -37,7 +37,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// <param name="x">The x position of the point on the curve</param>
 		/// <param name="y">The y position of the point on the curve</param>
 		public EcDsaJsonWebKey(
-			Guid id,
+			string id,
 			DateTime? expiresAt,
 			string curve,
 			string x,
@@ -55,7 +55,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		public override object ToJwkDto() {
 			if( ExpiresAt.HasValue ) {
 				return new {
-					kid = Id.ToString(),
+					kid = Id,
 					kty = "EC",
 					use = "sig",
 					crv = m_curve,
@@ -66,7 +66,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			}
 
 			return new {
-				kid = Id.ToString(),
+				kid = Id,
 				kty = "EC",
 				use = "sig",
 				crv = m_curve,

--- a/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
@@ -26,7 +26,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_dateTimeProvider = dateTimeProvider;
 		}
 
-		async Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( Guid id ) {
+		async Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( string id ) {
 			// We are intentionally fetching *all* public keys from the database
 			// here. This allows us to clean up all expired public keys even if
 			// GetAllAsync() is never explicitly called (e.g. when we switch from
@@ -74,7 +74,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			return m_inner.SaveAsync( key );
 		}
 
-		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {
+		Task IPublicKeyDataProvider.DeleteAsync( string id ) {
 			return m_inner.DeleteAsync( id );
 		}
 

--- a/src/D2L.Security.OAuth2/Keys/Default/IPublicKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/IPublicKeyProvider.cs
@@ -13,7 +13,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// </summary>
 		/// <param name="id">The key id (kid)</param>
 		/// <returns>The <see cref="D2LSecurityToken"/> or null if the key doesn't exist or has expired</returns>
-		Task<D2LSecurityToken> GetByIdAsync( Guid id );
+		Task<D2LSecurityToken> GetByIdAsync( string id );
 
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/JsonWebKeySet.cs
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_keys = ImmutableArray.Create( jsonWebKey );
 		}
 
-		public bool TryGetKey( Guid keyId, out JsonWebKey key ) {
+		public bool TryGetKey( string keyId, out JsonWebKey key ) {
 			foreach( JsonWebKey currentKey in m_keys ) {
 				if( currentKey.Id == keyId ) {
 					key = currentKey;

--- a/src/D2L.Security.OAuth2/Keys/Default/LocalPublicKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/LocalPublicKeyProvider.cs
@@ -28,7 +28,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_cache = cache;
 		}
 
-		async Task<D2LSecurityToken> IPublicKeyProvider.GetByIdAsync( Guid id ) {
+		async Task<D2LSecurityToken> IPublicKeyProvider.GetByIdAsync( string id ) {
 			D2LSecurityToken result = m_cache.Get( PUBLIC_KEY_SOURCE, id );
 			if( result != null ) {
 				return result;

--- a/src/D2L.Security.OAuth2/Keys/Default/RemotePublicKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/RemotePublicKeyProvider.cs
@@ -18,7 +18,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_cache = cache;
 		}
 
-		async Task<D2LSecurityToken> IPublicKeyProvider.GetByIdAsync( Guid id ) {
+		async Task<D2LSecurityToken> IPublicKeyProvider.GetByIdAsync( string id ) {
 			D2LSecurityToken result = m_cache.Get( m_jwksProvider.Namespace, id );
 			if( result != null ) {
 				return result;

--- a/src/D2L.Security.OAuth2/Keys/Default/RsaJsonWebKey.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/RsaJsonWebKey.cs
@@ -19,7 +19,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// <param name="expiresAt">When the key expires</param>
 		/// <param name="rsaParameters">The parameters needed to by the RSA algorithm</param>
 		public RsaJsonWebKey(
-			Guid id,
+			string id,
 			DateTime expiresAt,
 			RSAParameters rsaParameters
 		) : base( id, expiresAt ) {
@@ -34,7 +34,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// <param name="n">The RSA modulus</param>
 		/// <param name="e">The RSA exponent</param>
 		public RsaJsonWebKey(
-			Guid id,
+			string id,
 			DateTime? expiresAt,
 			string n,
 			string e
@@ -53,7 +53,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			if( ExpiresAt.HasValue ) {
 				return new {
-					kid = Id.ToString(),
+					kid = Id,
 					kty = "RSA",
 					use = "sig",
 					n = modulus,
@@ -63,7 +63,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			}
 
 			return new {
-				kid = Id.ToString(),
+				kid = Id,
 				kty = "RSA",
 				use = "sig",
 				n = modulus,

--- a/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
@@ -12,9 +12,9 @@ namespace D2L.Security.OAuth2.Keys.Development {
 	/// </summary>
 	[Obsolete( "Only use this in tests and for prototyping without a db" )]
 	public sealed class InMemoryPublicKeyDataProvider : IPublicKeyDataProvider {
-		private readonly ConcurrentDictionary<Guid, JsonWebKey> m_keys = new ConcurrentDictionary<Guid, JsonWebKey>();
+		private readonly ConcurrentDictionary<string, JsonWebKey> m_keys = new ConcurrentDictionary<string, JsonWebKey>();
 
-		Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( Guid id ) {
+		Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( string id ) {
 			if( !m_keys.TryGetValue( id, out JsonWebKey key ) ) {
 				return Task.FromResult<JsonWebKey>( null );
 			}
@@ -35,7 +35,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			return Task.Delay( 0 );
 		}
 
-		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {
+		Task IPublicKeyDataProvider.DeleteAsync( string id ) {
 			m_keys.TryRemove( id, out JsonWebKey removedKey );
 			return Task.Delay( 0 );
 		}

--- a/src/D2L.Security.OAuth2/Keys/Development/StaticPrivateKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Development/StaticPrivateKeyProvider.cs
@@ -24,7 +24,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		public Task<D2LSecurityToken> GetSigningCredentialsAsync() {
 			var creds = new D2LSecurityToken(
-				id: m_keyId,
+				id: m_keyId.ToString(),
 				validFrom: DateTime.UtcNow - TimeSpan.FromDays( 1 ),
 				validTo: DateTime.UtcNow + TimeSpan.FromDays( 365 ),
 				keyFactory: () => {

--- a/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
@@ -14,7 +14,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// </summary>
 		/// <param name="id">The key id (kid)</param>
 		/// <returns>The <see cref="JsonWebKey"/> or null if the key doesn't exist or has expired</returns>
-		Task<JsonWebKey> GetByIdAsync( Guid id );
+		Task<JsonWebKey> GetByIdAsync( string id );
 
 		/// <summary>
 		/// Gets all the <see cref="JsonWebKey"/> instances
@@ -32,7 +32,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// Deletes a key by key <paramref name="id"/> (kid)
 		/// </summary>
 		/// <param name="id">The key id (kid) of the key to delete</param>
-		Task DeleteAsync( Guid id );
+		Task DeleteAsync( string id );
 
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/JsonWebKey.cs
+++ b/src/D2L.Security.OAuth2/Keys/JsonWebKey.cs
@@ -14,7 +14,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// </summary>
 		public const string KEY_ID = "kid";
 
-		private readonly Guid m_id;
+		private readonly string m_id;
 		private readonly DateTime? m_expiresAt;
 
 		internal abstract D2LSecurityToken ToSecurityToken();
@@ -24,7 +24,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// </summary>
 		/// <param name="id">The key id (kid)</param>
 		/// <param name="expiresAt">When the key expires</param>
-		protected JsonWebKey( Guid id, DateTime? expiresAt ) {
+		protected JsonWebKey( string id, DateTime? expiresAt ) {
 			m_id = id;
 			m_expiresAt = expiresAt;
 		}
@@ -32,7 +32,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// <summary>
 		/// The key id (kid)
 		/// </summary>
-		public virtual Guid Id {
+		public virtual string Id {
 			get { return m_id; }
 		}
 
@@ -74,7 +74,7 @@ namespace D2L.Security.OAuth2.Keys {
 				throw new JsonWebKeyParseException( "missing 'kid' parameter in JSON web key" );
 			}
 
-			Guid id = Guid.Parse( data[ "kid" ].ToString() );
+			string id = data[ "kid" ].ToString();
 			DateTime? expiresAt = null;
 			if( data.ContainsKey( "exp" ) ) {
 				long ts = long.Parse( data[ "exp" ].ToString() );

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidator.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidator.cs
@@ -59,12 +59,9 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			}
 
 			string keyId = unvalidatedToken.Header[ "kid" ].ToString();
-			if( !Guid.TryParse( keyId, out Guid id ) ) {
-				throw new InvalidTokenException( string.Format( "Non-guid kid claim: {0}", keyId ) );
-			}
 
 			D2LSecurityToken signingToken = await m_publicKeyProvider
-				.GetByIdAsync( id )
+				.GetByIdAsync( keyId )
 				.SafeAsync();
 
 			var validationParameters = new TokenValidationParameters() {

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			HttpClient httpClient,
 			Uri authEndpoint
 		) {
-			var jwksProvider = new JwksProvider(
+			var jwksProvider = new D2LJwksProvider(
 				httpClient,
 				authEndpoint
 			);
@@ -52,5 +52,27 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			return result;
 		}
 
+		/// <summary>
+		/// Creates an <see cref="IAccessTokenValidator"/> for Standard OAuth2 instance backed by a remote token signer.
+		/// </summary>
+		/// <param name="httpClient"><see cref="HttpClient"/> instance with which requests will be made. The lifecycle of the <see cref="HttpClient"/> is not managed. It will not be disposed by the validator.</param>
+		/// <param name="authEndpoint">The URI of the remote JWKS file</param>
+		/// <returns></returns>
+		public static IAccessTokenValidator CreateRemoteStandardValidator(
+			HttpClient httpClient,
+			Uri authEndpoint
+		) {
+			var jwksProvider = new StandardJwksProvider(
+				httpClient,
+				authEndpoint
+			);
+			var publicKeyProvider = new RemotePublicKeyProvider(
+				jwksProvider,
+				new InMemoryPublicKeyCache()
+			);
+
+			var result = new AccessTokenValidator( publicKeyProvider );
+			return result;
+		}
 	}
 }

--- a/src/D2L.Security.OAuth2/Validation/Exceptions/PublicKeyNotFoundException.cs
+++ b/src/D2L.Security.OAuth2/Validation/Exceptions/PublicKeyNotFoundException.cs
@@ -16,7 +16,7 @@ namespace D2L.Security.OAuth2.Validation.Exceptions {
 		/// <summary>
 		/// Constructs a new <see cref="PublicKeyNotFoundException"/>
 		/// </summary>
-		public PublicKeyNotFoundException( Guid id, string source )
+		public PublicKeyNotFoundException( string id, string source )
 			: base( string.Format( "Could not find public key with id '{0}' from '{1}'", id, source ) ) { }
 	}
 }

--- a/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
+++ b/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {
 	internal abstract class FullStackValidationBenchmark : IBenchmark {
 		Action IBenchmark.GetRunner() {
-			SetUp( out Uri host, out string token, out Guid id );
+			SetUp( out Uri host, out string token, out string id );
 
 			IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator(
 				new HttpClient(),
@@ -26,7 +26,7 @@ namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {
 
 		protected abstract ITokenSigner GetTokenSigner( IPublicKeyDataProvider p );
 
-		private void SetUp( out Uri host, out string token, out Guid id ) {
+		private void SetUp( out Uri host, out string token, out string id ) {
 			var server = HttpMockFactory.Create( out string hostStr );
 
 			host = new Uri( hostStr );

--- a/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
+++ b/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
@@ -77,7 +77,8 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Keys\Default\Data\JwksProviderTests.cs" />
+    <Compile Include="Keys\Default\Data\StandardJwksProviderTests.cs" />
+    <Compile Include="Keys\Default\Data\D2LJwksProviderTests.cs" />
     <Compile Include="TestFramework\TestAccessTokenProviderTests.cs" />
     <Compile Include="TestFramework\TestAccessTokenTests.cs" />
     <Compile Include="Validation\AccessTokens\AccessTokenValidatorTests.Rsa.cs" />

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/D2LJwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/D2LJwksProviderTests.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using D2L.Security.OAuth2.TestFrameworks;
+using D2L.Security.OAuth2.Validation.Exceptions;
+using D2L.Services;
+using HttpMock;
+using NUnit.Framework;
+
+namespace D2L.Security.OAuth2.Keys.Default.Data {
+	[TestFixture]
+	public class D2LJwksProviderTests {
+		private const string GOOD_PATH = "/goodpath";
+		private const string BAD_PATH = "/badpath";
+		private const string HTML_PATH = "/html";
+		private const string JWKS_PATH = "/.well-known/jwks";
+
+		private static string GOOD_JWK_ID = Guid.NewGuid().ToString();
+		private static readonly string GOOD_JWK = @"{""kid"":""" + GOOD_JWK_ID + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
+		private static readonly string GOOD_JSON = @"{""keys"": [" + GOOD_JWK + "]}";
+		private static readonly string HTML = "<html><body><p>This isn't JSON eh</p></body></html>";
+		private static readonly string GOOD_JWK_PATH = GOOD_PATH + "/jwk/" + GOOD_JWK_ID;
+
+		private IHttpServer SetupJwkServer(
+			out string host,
+			bool hasJwk = true,
+			HttpStatusCode jwkStatusCode = HttpStatusCode.OK
+		) {
+			IHttpServer jwksServer = HttpMockFactory.Create( out host );
+
+			jwksServer.Stub(
+				x => x.Get( GOOD_PATH + JWKS_PATH )
+			).Return( GOOD_JSON ).OK();
+
+			jwksServer.Stub(
+				x => x.Get( BAD_PATH )
+			).Return( GOOD_JSON ).WithStatus( HttpStatusCode.InternalServerError );
+
+			jwksServer.Stub(
+				x => x.Get( HTML_PATH + JWKS_PATH )
+			).Return( HTML ).WithStatus( HttpStatusCode.OK );
+
+			jwksServer
+				.Stub( x => x.Get( GOOD_JWK_PATH ) )
+				.Return( hasJwk ? GOOD_JWK : "" )
+				.WithStatus( jwkStatusCode );
+
+			return jwksServer;
+		}
+
+		[Test]
+		public async Task SuccessCase() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await publicKeyProvider
+					.RequestJwksAsync()
+					.SafeAsync();
+
+				Assert.IsNotNull( jwks );
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_HTML_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + HTML_PATH )
+				);
+
+				var e = Assert.Throws<PublicKeyLookupFailureException>( () =>
+					publicKeyProvider
+						.RequestJwksAsync()
+						.SafeWait()
+					);
+
+				StringAssert.Contains( "<body>", e.Message );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_404_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + BAD_PATH )
+				);
+
+				Assert.ThrowsAsync<PublicKeyLookupFailureException>( async () => {
+					JsonWebKeySet jwks = await publicKeyProvider
+						.RequestJwksAsync()
+						.SafeAsync();
+				} );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_CantReachServer_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( "http://foo.bar.fakesite.isurehopethisisneveravalidTLD" )
+				);
+
+				Assert.ThrowsAsync<PublicKeyLookupFailureException>( async () => {
+					JsonWebKeySet jwks = await publicKeyProvider
+					.RequestJwksAsync()
+					.SafeAsync();
+				} );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_Success() {
+			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasNotCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_404_Fallback_Success() {
+			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_500_Fallback_Success() {
+			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new D2LJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
+				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
+	}
+}

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/StandardJwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/StandardJwksProviderTests.cs
@@ -10,22 +10,19 @@ using NUnit.Framework;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	[TestFixture]
-	public class JwksProviderTests {
+	public class StandardJwksProviderTests {
 		private const string GOOD_PATH = "/goodpath";
 		private const string BAD_PATH = "/badpath";
 		private const string HTML_PATH = "/html";
 		private const string JWKS_PATH = "/.well-known/jwks";
 
-		private static Guid GOOD_JWK_ID = Guid.NewGuid();
+		private static string GOOD_JWK_ID = Guid.NewGuid().ToString();
 		private static readonly string GOOD_JWK = @"{""kid"":""" + GOOD_JWK_ID + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
 		private static readonly string GOOD_JSON = @"{""keys"": [" + GOOD_JWK + "]}";
 		private static readonly string HTML = "<html><body><p>This isn't JSON eh</p></body></html>";
-		private static readonly string GOOD_JWK_PATH = GOOD_PATH + "/jwk/" + GOOD_JWK_ID;
 
 		private IHttpServer SetupJwkServer(
-			out string host,
-			bool hasJwk = true,
-			HttpStatusCode jwkStatusCode = HttpStatusCode.OK
+			out string host
 		) {
 			IHttpServer jwksServer = HttpMockFactory.Create( out host );
 
@@ -41,11 +38,6 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 				x => x.Get( HTML_PATH + JWKS_PATH )
 			).Return( HTML ).WithStatus( HttpStatusCode.OK );
 
-			jwksServer
-				.Stub( x => x.Get( GOOD_JWK_PATH ) )
-				.Return( hasJwk ? GOOD_JWK : "" )
-				.WithStatus( jwkStatusCode );
-
 			return jwksServer;
 		}
 
@@ -53,7 +45,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task SuccessCase() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -71,7 +63,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_HTML_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + HTML_PATH )
 				);
@@ -90,7 +82,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_404_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + BAD_PATH )
 				);
@@ -107,7 +99,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_CantReachServer_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( "http://foo.bar.fakesite.isurehopethisisneveravalidTLD" )
 				);
@@ -122,9 +114,9 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		[Test]
 		public async Task RequestJwkAsync_Success() {
-			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
+			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -136,50 +128,6 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
 				//jwksServer.AssertWasNotCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
-
-				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
-				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
-			}
-		}
-
-		[Test]
-		public async Task RequestJwkAsync_404_Fallback_Success() {
-			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound ) )
-			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
-					httpClient,
-					new Uri( host + GOOD_PATH )
-				);
-
-				JsonWebKeySet jwks = await jwksProvider
-					.RequestJwkAsync( GOOD_JWK_ID )
-					.SafeAsync();
-				Assert.IsNotNull( jwks );
-
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
-
-				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
-				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
-			}
-		}
-
-		[Test]
-		public async Task RequestJwkAsync_500_Fallback_Success() {
-			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
-			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
-					httpClient,
-					new Uri( host + GOOD_PATH )
-				);
-
-				JsonWebKeySet jwks = await jwksProvider
-					.RequestJwkAsync( GOOD_JWK_ID )
-					.SafeAsync();
-				Assert.IsNotNull( jwks );
-
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_JWK_PATH ) );
-				//jwksServer.AssertWasCalled( x => x.Get( GOOD_PATH + JWKS_PATH ) );
 
 				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
 				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/ExpiringPublicKeyDataProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/ExpiringPublicKeyDataProviderTests.cs
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_EmptyDb_ReturnsNull() {
-			Guid id = Guid.NewGuid();
+			string id = Guid.NewGuid().ToString();
 			m_mockPublicKeyDataProvider.Setup( kp => kp.GetByIdAsync( id ) ).ReturnsAsync( null );
 
 			JsonWebKey result = await m_publicKeyDataProvider
@@ -51,11 +51,11 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_InvalidId_ReturnsNull() {
-			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid() );
+			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			AddKeyToDb( key );
 
 
-			Guid id = Guid.NewGuid();
+			string id = Guid.NewGuid().ToString();
 			m_mockPublicKeyDataProvider.Setup( kp => kp.GetByIdAsync( id ) ).ReturnsAsync( null );
 
 			JsonWebKey result = await m_publicKeyDataProvider
@@ -67,7 +67,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_ValidId_ReturnsKey() {
-			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid() );
+			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			AddKeyToDb( key );
 
 			JsonWebKey result = await m_publicKeyDataProvider
@@ -80,7 +80,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_ExpiredKey_DeletesAndReturnsNull() {
-			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid(), NOW - TimeSpan.FromTicks( 1 ) );
+			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid().ToString(), NOW - TimeSpan.FromTicks( 1 ) );
 			AddKeyToDb( key );
 			m_mockPublicKeyDataProvider.Setup( kp => kp.DeleteAsync( key.Id ) ).Returns( Task.Delay( 0 ) );
 
@@ -95,8 +95,8 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_OtherKeyExpired_GetsDeletedAsWell() {
-			JsonWebKey freshKey = new JsonWebKeyStub( Guid.NewGuid() );
-			JsonWebKey expiredKey = new JsonWebKeyStub( Guid.NewGuid(), NOW - TimeSpan.FromTicks( 1 ) );
+			JsonWebKey freshKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
+			JsonWebKey expiredKey = new JsonWebKeyStub( Guid.NewGuid().ToString(), NOW - TimeSpan.FromTicks( 1 ) );
 			AddKeyToDb( freshKey );
 			AddKeyToDb( expiredKey );
 			m_mockPublicKeyDataProvider
@@ -128,8 +128,8 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetAll_MixOfKeys_ReturnsUnexpiredAndDeletesExpired() {
-			var goodIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-			var mehIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+			var goodIds = new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString() };
+			var mehIds = new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString() };
 			var keys = new[] {
 				new JsonWebKeyStub( goodIds[ 0 ] ),
 				new JsonWebKeyStub( mehIds[ 0 ], NOW - TimeSpan.FromTicks( 1 ) ),
@@ -154,7 +154,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 				.GetAllAsync()
 				.SafeAsync();
 
-			IEnumerable<Guid> ids = result.Select( k => k.Id );
+			IEnumerable<string> ids = result.Select( k => k.Id );
 
 			foreach( var id in mehIds ) {
 				var kid = id; // copy the GUID to appease the compiler

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/PrivateKeyProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/PrivateKeyProviderTests.cs
@@ -100,7 +100,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ), Times.Once() );
 			var ids = keys.Select( k => k.KeyId ).ToList();
-			foreach( Guid id in ids ) {
+			foreach( string id in ids ) {
 				Assert.AreEqual( ids[ 0 ], id );
 			}
 		}

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/RemotePublicKeyProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/RemotePublicKeyProviderTests.cs
@@ -17,14 +17,14 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		private IPublicKeyProvider m_publicKeyProvider;
 
 		private string SRC_NAMESPACE;
-		private Guid KEY_ID;
+		private string KEY_ID;
 
 		[SetUp]
 		public void BeforeEach() {
 			m_jwksProvider = new Mock<IJwksProvider>( MockBehavior.Strict );
 			m_keyCache = new Mock<IInMemoryPublicKeyCache>( MockBehavior.Strict );
 			SRC_NAMESPACE = Guid.NewGuid().ToString();
-			KEY_ID = Guid.NewGuid();
+			KEY_ID = Guid.NewGuid().ToString();
 
 			m_jwksProvider
 				.Setup( x => x.Namespace )
@@ -68,7 +68,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 				.Setup( x => x.Get( SRC_NAMESPACE, KEY_ID ) )
 				.Returns<D2LSecurityToken>( null );
 
-			var otherKeyId = Guid.NewGuid();
+			var otherKeyId = Guid.NewGuid().ToString();
 			var jwks = new JsonWebKeySet(
 				new JavaScriptSerializer().Serialize(
 					new {
@@ -125,7 +125,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 				.Setup( x => x.Get( SRC_NAMESPACE, KEY_ID ) )
 				.Returns<D2LSecurityToken>( null );
 
-			var otherKeyId = Guid.NewGuid();
+			var otherKeyId = Guid.NewGuid().ToString();
 			var jwks = new JsonWebKeySet(
 				new JavaScriptSerializer().Serialize(
 					new {

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
@@ -19,24 +19,24 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_NoKeys_ReturnsNull() {
-			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid() ).SafeAsync();
+			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid().ToString() ).SafeAsync();
 
 			Assert.IsNull( key );
 		}
 
 		[Test]
 		public async Task GetById_IncorrectId_ReturnsKey() {
-			var dummyKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
 
-			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid() ).SafeAsync();
+			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid().ToString() ).SafeAsync();
 
 			Assert.IsNull( key );
 		}
 
 		[Test]
 		public async Task GetById_CorrectId_ReturnsKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
 
 			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
@@ -47,9 +47,9 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_CorrectIdWithOthers_ReturnsKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
-			var dummyKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
 
 			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
@@ -68,10 +68,10 @@ namespace D2L.Security.OAuth2.Keys.Development {
 		[Test]
 		public async Task GetAll_ReturnsAllSavedKeys() {
 			var expected = new[] {
-				new JsonWebKeyStub( Guid.NewGuid() ),
-				new JsonWebKeyStub( Guid.NewGuid() ),
-				new JsonWebKeyStub( Guid.NewGuid() ),
-				new JsonWebKeyStub( Guid.NewGuid() )
+				new JsonWebKeyStub( Guid.NewGuid().ToString() ),
+				new JsonWebKeyStub( Guid.NewGuid().ToString() ),
+				new JsonWebKeyStub( Guid.NewGuid().ToString() ),
+				new JsonWebKeyStub( Guid.NewGuid().ToString() )
 			};
 
 			foreach( var key in expected ) {
@@ -87,7 +87,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task SaveAsync_DoubleSave_ThrowsException() {
-			var key = new JsonWebKeyStub( Guid.NewGuid() );
+			var key = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( key ).SafeAsync();
 
 			Assert.Throws<InvalidOperationException>( () => m_publicKeyDataProvider.SaveAsync( key ).Wait() );
@@ -95,14 +95,14 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public void DeleteAsync_MissingKey_DoesntThrow() {
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid() ).Wait() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid().ToString() ).Wait() );
 		}
 
 		[Test]
 		public async Task DeleteAsync_DoesntDeleteOtherKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid() ).Wait() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid().ToString() ).Wait() );
 			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
 
 			Assert.IsNotNull( actualKey );
@@ -111,7 +111,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task DeleteAsync_DoesSeemToDeleteKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
 			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
 
@@ -120,7 +120,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task DeleteAsync_DoubleDelete_DoesSeemToDeleteKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid() );
+			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
 			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
 			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
@@ -12,7 +12,7 @@ namespace D2L.Security.OAuth2.Keys {
 	internal sealed class JsonWebKeyTests {
 		[Test]
 		public void FromJson_ParsesStaticRsaKeyWithoutExp() {
-			Guid id = Guid.NewGuid();
+			string id = Guid.NewGuid().ToString();
 			string example =
 				@"{""kid"":""" + id + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
 
@@ -24,7 +24,7 @@ namespace D2L.Security.OAuth2.Keys {
 
 		[Test]
 		public void FromJson_ParsesStaticRsaKeyWithExp() {
-			Guid id = Guid.NewGuid();
+			string id = Guid.NewGuid().ToString();
 			long exp = ( long )DateTime.UtcNow.TimeSinceUnixEpoch().TotalSeconds;
 			string example =
 				@"{""exp"":" + exp + @",""kid"":""" + id + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
@@ -43,7 +43,7 @@ namespace D2L.Security.OAuth2.Keys {
 		public void FromJson_ParsesStaticEcKeyWithoutExp( string jwk ) {
 			JsonWebKey key = JsonWebKey.FromJson( jwk );
 
-			Assert.AreEqual( Guid.Parse( "fae33c85-e421-40f5-bebb-8ec8ab778be4" ), key.Id );
+			Assert.AreEqual( "fae33c85-e421-40f5-bebb-8ec8ab778be4", key.Id );
 			Assert.IsFalse( key.ExpiresAt.HasValue );
 
 			Assert.DoesNotThrow( () => key.ToSecurityToken() );

--- a/test/D2L.Security.OAuth2.UnitTests/TestUtilities/D2LSecurityTokenUtility.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/TestUtilities/D2LSecurityTokenUtility.cs
@@ -5,7 +5,7 @@ using D2L.Security.OAuth2.Keys.Default;
 
 namespace D2L.Security.OAuth2.TestUtilities {
 	internal static class D2LSecurityTokenUtility {
-		public static D2LSecurityToken CreateActiveToken( Guid? id = null ) {
+		public static D2LSecurityToken CreateActiveToken( string id = null ) {
 			return CreateTokenWithTimeRemaining(
 				TimeSpan.FromHours( 1 ) - TimeSpan.FromSeconds( 1 ),
 				id );
@@ -13,10 +13,10 @@ namespace D2L.Security.OAuth2.TestUtilities {
 
 		public static D2LSecurityToken CreateTokenWithTimeRemaining(
 			TimeSpan remaining,
-			Guid? id = null
+			string id = null
 		) {
 
-			id = id ?? Guid.NewGuid();
+			id = id ?? Guid.NewGuid().ToString();
 
 			var validTo = DateTime.UtcNow + remaining;
 			var validFrom = validTo - TimeSpan.FromHours( 1 );
@@ -29,7 +29,7 @@ namespace D2L.Security.OAuth2.TestUtilities {
 			}
 
 			return new D2LSecurityToken(
-				id.Value,
+				id,
 				validFrom,
 				validTo,
 				keyFactory: () => {

--- a/test/D2L.Security.OAuth2.UnitTests/TestUtilities/JsonWebKeyStub.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/TestUtilities/JsonWebKeyStub.cs
@@ -6,8 +6,8 @@ namespace D2L.Security.OAuth2.TestUtilities {
 	internal class JsonWebKeyStub : JsonWebKey {
 		public static readonly TimeSpan KEY_LIFETIME = TimeSpan.FromHours( 1 );
 
-		public JsonWebKeyStub( Guid id ) : base( id, DateTime.UtcNow + KEY_LIFETIME ) { }
-		public JsonWebKeyStub( Guid id, DateTime expiresAt ) : base( id, expiresAt ) { }
+		public JsonWebKeyStub( string id ) : base( id, DateTime.UtcNow + KEY_LIFETIME ) { }
+		public JsonWebKeyStub( string id, DateTime expiresAt ) : base( id, expiresAt ) { }
 
 		public override object ToJwkDto() {
 			throw new NotImplementedException();

--- a/test/D2L.Security.OAuth2.UnitTests/TestUtilities/Mocks/PublicKeyProviderMock.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/TestUtilities/Mocks/PublicKeyProviderMock.cs
@@ -7,7 +7,7 @@ namespace D2L.Security.OAuth2.TestUtilities.Mocks {
 	public static class PublicKeyProviderMock {
 		internal static Mock<IPublicKeyProvider> Create(
 			Uri jwksEndpoint,
-			Guid keyId,
+			string keyId,
 			D2LSecurityToken token
 		) {
 			var mock = new Mock<IPublicKeyProvider>();

--- a/test/D2L.Security.OAuth2.UnitTests/Validation/AccessTokenValidatorTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Validation/AccessTokenValidatorTests.cs
@@ -74,7 +74,7 @@ namespace D2L.Security.OAuth2.Validation {
 			DateTime jwtExpiry,
 			Type expectedExceptionType = null
 		) {
-			Guid keyId = Guid.NewGuid();
+			string keyId = Guid.NewGuid().ToString();
 			D2LSecurityToken signingToken = D2LSecurityTokenUtility.CreateActiveToken( id: keyId );
 			SigningCredentials signingCredentials = null;
 			if( signJwt ) {


### PR DESCRIPTION
Adds a standard JWKS provider, and changes the keyId data type from Guid
to string to allow for arbitrary kid values.
Adds a new factory method to AccessTokenValidatorFactory to support
validation using the standard JWKS provider.

Updated the changes in https://git.dev.d2l/projects/AUTH/repos/auth-service/pull-requests/490 to pivot to this approach.