### PR TITLE
Add Standard JWKS Provider to support 3rd party endpoints

### DIFF
--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -83,6 +83,7 @@
       <DependentUpon>D2LSecurityToken.cs</DependentUpon>
     </Compile>
     <Compile Include="Keys\Default\D2LSecurityTokenFactory.cs" />
+    <Compile Include="Keys\Default\Data\StandardJwksProvider.cs" />
     <Compile Include="Keys\Default\EcDsaJsonWebKey.cs" />
     <Compile Include="Keys\Default\EcDsaJsonWebKey.ECCPublicKeyBlobFormatter.cs">
       <DependentUpon>EcDsaJsonWebKey.cs</DependentUpon>
@@ -125,7 +126,7 @@
     <Compile Include="Keys\Default\IPrivateKeyProvider.cs" />
     <Compile Include="Keys\Default\IPublicKeyProvider.cs" />
     <Compile Include="Keys\Default\Data\IJwksProvider.cs" />
-    <Compile Include="Keys\Default\Data\JwksProvider.cs" />
+    <Compile Include="Keys\Default\Data\D2LJwksProvider.cs" />
     <Compile Include="Keys\RsaTokenSignerFactory.cs" />
     <Compile Include="Keys\TokenSignerFactory.cs" />
     <Compile Include="Keys\UnsignedToken.cs" />

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/D2LJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/D2LJwksProvider.cs
@@ -7,11 +7,11 @@ using D2L.Security.OAuth2.Validation.Exceptions;
 using D2L.Services;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
-	internal sealed class JwksProvider : IJwksProvider {
+	internal sealed class D2LJwksProvider : IJwksProvider {
 		private readonly HttpClient m_httpClient;
 		private readonly Uri m_authEndpoint;
 
-		public JwksProvider(
+		public D2LJwksProvider(
 			HttpClient httpClient,
 			Uri authEndpoint
 		) {

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/StandardJwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/StandardJwksProvider.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using D2L.Security.OAuth2.Validation.Exceptions;
+using D2L.Services;
+
+namespace D2L.Security.OAuth2.Keys.Default.Data {
+	class StandardJwksProvider : IJwksProvider {
+		private readonly HttpClient m_httpClient;
+		private readonly Uri m_authEndpoint;
+
+		public StandardJwksProvider(
+			HttpClient httpClient,
+			Uri authEndpoint
+		) {
+			m_httpClient = httpClient;
+			m_authEndpoint = authEndpoint;
+		}
+
+		string IJwksProvider.Namespace => m_authEndpoint.AbsoluteUri;
+
+		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( string keyId ) {
+			return await RequestJwksAsync();
+		}
+
+		async Task<JsonWebKeySet> IJwksProvider.RequestJwksAsync() {
+			return await RequestJwksAsync();
+		}
+
+		private async Task<JsonWebKeySet> RequestJwksAsync() {
+			try {
+				using( HttpResponseMessage response = await m_httpClient.GetAsync( m_authEndpoint ).SafeAsync() ) {
+					response.EnsureSuccessStatusCode();
+					string jsonResponse = await response.Content.ReadAsStringAsync().SafeAsync();
+					var jwks = new JsonWebKeySet( jsonResponse, m_authEndpoint );
+					return jwks;
+				}
+			} catch( HttpRequestException e ) {
+				throw CreateException( e, m_authEndpoint );
+			} catch( JsonWebKeyParseException e ) {
+				throw CreateException( e, m_authEndpoint );
+			}
+		}
+
+		private Exception CreateException( Exception e, Uri endpoint ) {
+			string message = $"Error while looking up key(s) at {endpoint}: {e.Message}";
+
+			return new PublicKeyLookupFailureException( message, e );
+		}
+	}
+}

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			HttpClient httpClient,
 			Uri authEndpoint
 		) {
-			var jwksProvider = new JwksProvider(
+			var jwksProvider = new D2LJwksProvider(
 				httpClient,
 				authEndpoint
 			);
@@ -52,5 +52,27 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 			return result;
 		}
 
+		/// <summary>
+		/// Creates an <see cref="IAccessTokenValidator"/> instance backed by a remote token signer for explicit JWKS endpoints.
+		/// </summary>
+		/// <param name="httpClient"><see cref="HttpClient"/> instance with which requests will be made. The lifecycle of the <see cref="HttpClient"/> is not managed. It will not be disposed by the validator.</param>
+		/// <param name="authEndpoint">The base URI of the remote service</param>
+		/// <returns>A new <see cref="IAccessTokenValidator"/></returns>
+		public static IAccessTokenValidator CreateStandardRemoteValidator(
+			HttpClient httpClient,
+			Uri authEndpoint
+		) {
+			var jwksProvider = new StandardJwksProvider(
+				httpClient,
+				authEndpoint
+			);
+			var publicKeyProvider = new RemotePublicKeyProvider(
+				jwksProvider,
+				new InMemoryPublicKeyCache()
+			);
+
+			var result = new AccessTokenValidator( publicKeyProvider );
+			return result;
+		}
 	}
 }

--- a/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
+++ b/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
@@ -77,7 +77,8 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Keys\Default\Data\JwksProviderTests.cs" />
+    <Compile Include="Keys\Default\Data\StandardJwksProviderTests.cs" />
+    <Compile Include="Keys\Default\Data\D2LJwksProviderTests.cs" />
     <Compile Include="TestFramework\TestAccessTokenProviderTests.cs" />
     <Compile Include="TestFramework\TestAccessTokenTests.cs" />
     <Compile Include="Validation\AccessTokens\AccessTokenValidatorTests.Rsa.cs" />

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/D2LJwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/D2LJwksProviderTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	[TestFixture]
-	public class JwksProviderTests {
+	public class D2LJwksProviderTests {
 		private const string GOOD_PATH = "/goodpath";
 		private const string BAD_PATH = "/badpath";
 		private const string HTML_PATH = "/html";
@@ -61,7 +61,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task SuccessCase() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -80,7 +80,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_HTML_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + HTML_PATH )
 				);
@@ -99,7 +99,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_404_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + BAD_PATH )
 				);
@@ -116,7 +116,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public void RequestJwksAsync_CantReachServer_Throws() {
 			using( SetupJwkServer( out string host ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider publicKeyProvider = new JwksProvider(
+				IJwksProvider publicKeyProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( "http://foo.bar.fakesite.isurehopethisisneveravalidTLD" )
 				);
@@ -133,7 +133,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_Success() {
 			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -155,7 +155,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_StringKeyId_Success() {
 			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -177,7 +177,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_StringKeyId_InvalidKeyId_Fallback_DoesNotReturnKey() {
 			using( SetupJwkServer( out string host, hasJwk: true, jwkStatusCode: HttpStatusCode.OK ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -198,7 +198,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_404_Fallback_Success() {
 			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -220,7 +220,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_StringKeyId_404_Fallback_Success() {
 			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.NotFound ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -242,7 +242,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_500_Fallback_Success() {
 			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);
@@ -264,7 +264,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		public async Task RequestJwkAsync_StringKeyId_500_Fallback_Success() {
 			using( SetupJwkServer( out string host, hasJwk: false, jwkStatusCode: HttpStatusCode.InternalServerError ) )
 			using( HttpClient httpClient = new HttpClient() ) {
-				IJwksProvider jwksProvider = new JwksProvider(
+				IJwksProvider jwksProvider = new D2LJwksProvider(
 					httpClient,
 					new Uri( host + GOOD_PATH )
 				);

--- a/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/StandardJwksProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Keys/Default/Data/StandardJwksProviderTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using D2L.Security.OAuth2.TestFrameworks;
+using D2L.Security.OAuth2.Validation.Exceptions;
+using D2L.Services;
+using HttpMock;
+using NUnit.Framework;
+
+namespace D2L.Security.OAuth2.Keys.Default.Data {
+	[TestFixture]
+	public class StandardJwksProviderTests {
+		private const string GOOD_PATH = "/goodpath";
+		private const string BAD_PATH = "/badpath";
+		private const string HTML_PATH = "/html";
+		private const string JWKS_PATH = "/.well-known/jwks";
+
+		private static string GOOD_JWK_ID = Guid.NewGuid().ToString();
+		private static readonly string GOOD_JWK = @"{""kid"":""" + GOOD_JWK_ID + @""",""kty"":""RSA"",""use"":""sig"",""n"":""piXmF9_L0UO4K5APzHqiOYl_KtVXAgPlVHhUopPztaW_JRh2k9MDeupIA1cAF9S_r5qRBWcA1QaP0nlGalw3jm_fSHvtUYYhwUhF9X6I19VRmv_BX9Ne2budt5dafI9DbNs2Ltq0X_yfM1dUL81vaR0rz7jYaQ5bF2CRQHVCcIhWkik85PG5c1yK__As842WqogBpW8-zsEoB6s53FNpDG37_HsZAAngATmTY1At4O7jC6p-c0KVPDf25oLVMOWQubyVgCE9FlsVxprHWqsXenlnHEmhZfEbFB_5KB6hj2yV77jhvLRslNvyKflFBs6AGCiczNDzmoXH2GV3FAVLFQ"",""e"":""AQAB""}";
+		private static readonly string GOOD_JSON = @"{""keys"": [" + GOOD_JWK + "]}";
+		private static readonly string HTML = "<html><body><p>This isn't JSON eh</p></body></html>";
+
+		private IHttpServer SetupJwkServer(
+			out string host
+		) {
+			IHttpServer jwksServer = HttpMockFactory.Create( out host );
+
+			jwksServer.Stub(
+				x => x.Get( GOOD_PATH + JWKS_PATH )
+			).Return( GOOD_JSON ).OK();
+
+			jwksServer.Stub(
+				x => x.Get( BAD_PATH + JWKS_PATH )
+			).Return( GOOD_JSON ).WithStatus( HttpStatusCode.InternalServerError );
+
+			jwksServer.Stub(
+				x => x.Get( HTML_PATH )
+			).Return( HTML ).WithStatus( HttpStatusCode.OK );
+
+			return jwksServer;
+		}
+
+		[Test]
+		public async Task SuccessCase() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new StandardJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH + JWKS_PATH )
+				);
+
+				JsonWebKeySet jwks = await publicKeyProvider
+					.RequestJwksAsync()
+					.SafeAsync();
+
+				Assert.IsNotNull( jwks );
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_HTML_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new StandardJwksProvider(
+					httpClient,
+					new Uri( host + HTML_PATH )
+				);
+
+				var e = Assert.Throws<PublicKeyLookupFailureException>( () =>
+					publicKeyProvider
+						.RequestJwksAsync()
+						.SafeWait()
+					);
+
+				StringAssert.Contains( "<body>", e.Message );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_404_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new StandardJwksProvider(
+					httpClient,
+					new Uri( host + BAD_PATH + JWKS_PATH )
+				);
+
+				Assert.ThrowsAsync<PublicKeyLookupFailureException>( async () => {
+					JsonWebKeySet jwks = await publicKeyProvider
+						.RequestJwksAsync()
+						.SafeAsync();
+				} );
+			}
+		}
+
+		[Test]
+		public void RequestJwksAsync_CantReachServer_Throws() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider publicKeyProvider = new StandardJwksProvider(
+					httpClient,
+					new Uri( "http://foo.bar.fakesite.isurehopethisisneveravalidTLD" )
+				);
+
+				Assert.ThrowsAsync<PublicKeyLookupFailureException>( async () => {
+					JsonWebKeySet jwks = await publicKeyProvider
+					.RequestJwksAsync()
+					.SafeAsync();
+				} );
+			}
+		}
+
+		[Test]
+		public async Task RequestJwkAsync_Success() {
+			using( SetupJwkServer( out string host ) )
+			using( HttpClient httpClient = new HttpClient() ) {
+				IJwksProvider jwksProvider = new StandardJwksProvider(
+					httpClient,
+					new Uri( host + GOOD_PATH + JWKS_PATH )
+				);
+
+				JsonWebKeySet jwks = await jwksProvider
+					.RequestJwkAsync( GOOD_JWK_ID )
+					.SafeAsync();
+				Assert.IsNotNull( jwks );
+
+				Assert.IsTrue( jwks.TryGetKey( GOOD_JWK_ID, out JsonWebKey jwk ) );
+				Assert.AreEqual( GOOD_JWK_ID, jwk.Id );
+			}
+		}
+	}
+}


### PR DESCRIPTION
This builds on #115 to add the standard JWKS provider

This is the last of my planned updates to the library for LTI support.