### PR TITLE
Update JWKS provider for full JWKS Uri, and optional JWK Uri

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
@@ -39,11 +39,11 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 
 		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( string keyId ) {
 			var url = GetJwkEndpoint( m_jwkEndpoint, keyId );
-			try {
-				if( url == null ) {
-					return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
-				}
+			if( url == null ) {
+				return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
+			}
 
+			try {
 				using( var res = await m_httpClient.GetAsync( url ).SafeAsync() ) {
 					// This is temporary while we try to fully deprecate the
 					// JWKS route. 404 might mean the key doesn't exist (which

--- a/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/Data/JwksProvider.cs
@@ -9,36 +9,41 @@ using D2L.Services;
 namespace D2L.Security.OAuth2.Keys.Default.Data {
 	internal sealed class JwksProvider : IJwksProvider {
 		private readonly HttpClient m_httpClient;
-		private readonly Uri m_authEndpoint;
+		private readonly Uri m_jwksEndpoint;
+		private readonly Uri m_jwkEndpoint;
 
 		public JwksProvider(
 			HttpClient httpClient,
-			Uri authEndpoint
+			Uri jwksEndpoint,
+			Uri jwkEndpoint
 		) {
 			m_httpClient = httpClient;
-			m_authEndpoint = authEndpoint;
+			m_jwksEndpoint = jwksEndpoint;
+			m_jwkEndpoint = jwkEndpoint;
 		}
 
 		async Task<JsonWebKeySet> IJwksProvider.RequestJwksAsync() {
-			var url = GetJwksEndpoint( m_authEndpoint );
-
 			try {
-				using( HttpResponseMessage response = await m_httpClient.GetAsync( url ).SafeAsync() ) {
+				using( HttpResponseMessage response = await m_httpClient.GetAsync( m_jwksEndpoint ).SafeAsync() ) {
 					response.EnsureSuccessStatusCode();
 					string jsonResponse = await response.Content.ReadAsStringAsync().SafeAsync();
-					var jwks = new JsonWebKeySet( jsonResponse, url );
+					var jwks = new JsonWebKeySet( jsonResponse, m_jwksEndpoint );
 					return jwks;
 				}
 			} catch( HttpRequestException e ) {
-				throw CreateException( e, url );
+				throw CreateException( e, m_jwksEndpoint );
 			} catch( JsonWebKeyParseException e ) {
-				throw CreateException( e, url );
+				throw CreateException( e, m_jwksEndpoint );
 			}
 		}
 
 		async Task<JsonWebKeySet> IJwksProvider.RequestJwkAsync( string keyId ) {
-			var url = GetJwkEndpoint( m_authEndpoint, keyId );
+			var url = GetJwkEndpoint( m_jwkEndpoint, keyId );
 			try {
+				if( url == null ) {
+					return await ( this as IJwksProvider ).RequestJwksAsync().SafeAsync();
+				}
+
 				using( var res = await m_httpClient.GetAsync( url ).SafeAsync() ) {
 					// This is temporary while we try to fully deprecate the
 					// JWKS route. 404 might mean the key doesn't exist (which
@@ -70,7 +75,7 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 			}
 		}
 
-		string IJwksProvider.Namespace => m_authEndpoint.AbsoluteUri;
+		string IJwksProvider.Namespace => m_jwksEndpoint.AbsoluteUri;
 
 		private Exception CreateException( Exception e, Uri endpoint ) {
 			string message = $"Error while looking up key(s) at {endpoint}: {e.Message}";
@@ -79,17 +84,11 @@ namespace D2L.Security.OAuth2.Keys.Default.Data {
 		}
 
 		private static Uri GetJwkEndpoint( Uri authEndpoint, string keyId ) {
+			if( authEndpoint == null ) { return null; }
+
 			string authRoot = MakeSureThereIsATrailingSlash( authEndpoint );
 
-			authRoot += $"jwk/{HttpUtility.UrlEncode( keyId )}";
-
-			return new Uri( authRoot );
-		}
-
-		private static Uri GetJwksEndpoint( Uri authEndpoint ) {
-			string authRoot = MakeSureThereIsATrailingSlash( authEndpoint );
-
-			authRoot += ".well-known/jwks";
+			authRoot += HttpUtility.UrlEncode( keyId );
 
 			return new Uri( authRoot );
 		}

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidatorFactory.cs
@@ -33,15 +33,18 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 		/// Creates an <see cref="IAccessTokenValidator"/> instance backed by a remote token signer.
 		/// </summary>
 		/// <param name="httpClient"><see cref="HttpClient"/> instance with which requests will be made. The lifecycle of the <see cref="HttpClient"/> is not managed. It will not be disposed by the validator.</param>
-		/// <param name="authEndpoint">The base URI of the remote service</param>
+		/// <param name="jwksEndpoint">The full URI of the remote JWKS</param>
+		/// <param name="jwkEndpoint">The full URI of the remote JWK path</param>
 		/// <returns>A new <see cref="IAccessTokenValidator"/></returns>
 		public static IAccessTokenValidator CreateRemoteValidator(
 			HttpClient httpClient,
-			Uri authEndpoint
+			Uri jwksEndpoint,
+			Uri jwkEndpoint = null
 		) {
 			var jwksProvider = new JwksProvider(
 				httpClient,
-				authEndpoint
+				jwksEndpoint,
+				jwkEndpoint
 			);
 			var publicKeyProvider = new RemotePublicKeyProvider(
 				jwksProvider,

--- a/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
+++ b/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
@@ -16,7 +16,8 @@ namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {
 
 			IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator(
 				new HttpClient(),
-				host
+				host,
+				null
 			);
 
 			return delegate {
@@ -29,7 +30,7 @@ namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {
 		private void SetUp( out Uri host, out string token, out string id ) {
 			var server = HttpMockFactory.Create( out string hostStr );
 
-			host = new Uri( hostStr );
+			host = new Uri( hostStr + "/.well-known/jwks" );
 
 #pragma warning disable 618
 			IPublicKeyDataProvider publicKeyDataProvider = new InMemoryPublicKeyDataProvider();

--- a/test/D2L.Security.OAuth2.IntegrationTests/TestFramework/TestAccessTokenProviderTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/TestFramework/TestAccessTokenProviderTests.cs
@@ -13,6 +13,8 @@ namespace D2L.Security.OAuth2.TestFramework {
 	[TestFixture]
 	internal sealed class TestAccessTokenProviderTests {
 		private const string DEV_AUTH_URL = "https://dev-auth.brightspace.com/core";
+		private const string DEV_AUTH_JWKS_URL = "https://dev-auth.brightspace.com/core/.well-known/jwks";
+		private const string DEV_AUTH_JWK_URL = "https://dev-auth.brightspace.com/core/jwk/";
 
 		private readonly ClaimSet testClaimSet = new ClaimSet( "ExpandoClient", Guid.NewGuid() );
 		private readonly Scope[] testScopes = {
@@ -25,7 +27,7 @@ namespace D2L.Security.OAuth2.TestFramework {
 				IAccessTokenProvider provider = TestAccessTokenProviderFactory.Create( httpClient, DEV_AUTH_URL );
 				IAccessToken token = await provider.ProvisionAccessTokenAsync( testClaimSet, testScopes ).SafeAsync();
 
-				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ) );
+				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_JWKS_URL ), new Uri( DEV_AUTH_JWK_URL ) );
 				Assert.DoesNotThrowAsync( async () => await validator.ValidateAsync( token.Token ).SafeAsync() );
 			}
 		}
@@ -36,7 +38,7 @@ namespace D2L.Security.OAuth2.TestFramework {
 				IAccessTokenProvider provider = TestAccessTokenProviderFactory.Create( httpClient, DEV_AUTH_URL, TestStaticKeyProvider.TestKeyId, TestStaticKeyProvider.TestRSAParameters );
 				IAccessToken token = await provider.ProvisionAccessTokenAsync( testClaimSet, testScopes ).SafeAsync();
 
-				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ) );
+				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_JWKS_URL ), new Uri( DEV_AUTH_JWK_URL ) );
 				Assert.DoesNotThrowAsync( async () => await validator.ValidateAsync( token.Token ).SafeAsync() );
 			}
 		}

--- a/test/D2L.Security.OAuth2.IntegrationTests/TestFramework/TestAccessTokenTests.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/TestFramework/TestAccessTokenTests.cs
@@ -11,13 +11,15 @@ namespace D2L.Security.OAuth2.TestFramework {
 	[TestFixture]
 	internal sealed class TestAccessTokenTests {
 		private const string DEV_AUTH_URL = "https://dev-auth.brightspace.com/core";
+		private const string DEV_AUTH_JWKS_URL = "https://dev-auth.brightspace.com/core/.well-known/jwks";
+		private const string DEV_AUTH_JWK_URL = "https://dev-auth.brightspace.com/core/jwk/";
 
 		[Test]
 		public async Task TestGetToken_WithTenantID_IsValid() {
 			string token = await TestAccessToken.GetToken( DEV_AUTH_URL, Guid.NewGuid().ToString() ).SafeAsync();
 
 			using( var httpClient = new HttpClient() ) {
-				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ) );
+				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ), new Uri( DEV_AUTH_JWK_URL ) );
 				Assert.DoesNotThrowAsync( async () => await validator.ValidateAsync( token ).SafeAsync() );
 			}
 		}
@@ -27,7 +29,7 @@ namespace D2L.Security.OAuth2.TestFramework {
 			string token = await TestAccessToken.GetToken( DEV_AUTH_URL, Guid.NewGuid().ToString(), "user", "xsrf" ).SafeAsync();
 
 			using( var httpClient = new HttpClient() ) {
-				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ) );
+				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ), new Uri( DEV_AUTH_JWK_URL ) );
 				Assert.DoesNotThrowAsync( async () => await validator.ValidateAsync( token ).SafeAsync() );
 			}
 
@@ -40,7 +42,7 @@ namespace D2L.Security.OAuth2.TestFramework {
 			string token = await TestAccessToken.GetToken( DEV_AUTH_URL, claims, scopes ).SafeAsync();
 
 			using( var httpClient = new HttpClient() ) {
-				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ) );
+				IAccessTokenValidator validator = AccessTokenValidatorFactory.CreateRemoteValidator( httpClient, new Uri( DEV_AUTH_URL ), new Uri( DEV_AUTH_JWK_URL ) );
 				Assert.DoesNotThrowAsync( async () => await validator.ValidateAsync( token ).SafeAsync() );
 			}
 

--- a/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.EcDsa.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.EcDsa.cs
@@ -21,7 +21,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 				m_authService = new AuthServiceMock( AuthServiceMock.KeyType.ECDSA_P256 );
 				m_accessTokenValidator = AccessTokenValidatorFactory.CreateRemoteValidator(
 					new HttpClient(),
-					m_authService.Host
+					new Uri( m_authService.Host, ".well-known/jwks" )
 				);
 
 				m_authService.SetupJwks().Wait();
@@ -121,7 +121,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 				// The rest of the validation should have otherwise proceeded swimmingly
 				Assert.Throws<ExpiredTokenException>( () =>
 					AccessTokenValidatorFactory
-						.CreateRemoteValidator( new HttpClient(), new Uri( host ) )
+						.CreateRemoteValidator( new HttpClient(), new Uri( host + "/.well-known/jwks" ) )
 						.ValidateAsync( token )
 						.SafeAsync().GetAwaiter().GetResult()
 				);

--- a/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.Rsa.cs
+++ b/test/D2L.Security.OAuth2.IntegrationTests/Validation/AccessTokens/AccessTokenValidatorTests.Rsa.cs
@@ -21,7 +21,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 				m_authService = new AuthServiceMock();
 				m_accessTokenValidator = AccessTokenValidatorFactory.CreateRemoteValidator(
 					new HttpClient(),
-					m_authService.Host
+					new Uri( m_authService.Host, ".well-known/jwks" )
 				);
 
 				m_authService.SetupJwks().Wait();


### PR DESCRIPTION
As per discussion with @j3parker

- Will need to migrate Auth Service `public_key_endpoint` to:
  - jwks_endpoint: `x => x + /.well-known/jwks`
  - jwk_endpoint: `x => x + /jwk/`