### PR TITLE
Revert IPublicKeyDataProvider back to Guid

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
@@ -47,7 +47,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			// how GetAllAsync is implemented at the moment, but still.
 			keys = keys.ToList();
 
-			JsonWebKey key = keys.SingleOrDefault( jwk => jwk.Id.KeyIdEquals( id.ToString() ) );
+			JsonWebKey key = keys.SingleOrDefault( jwk => new Guid( jwk.Id ) == id );
 
 			return key;
 		}

--- a/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
@@ -26,7 +26,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_dateTimeProvider = dateTimeProvider;
 		}
 
-		async Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( string id ) {
+		async Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( Guid id ) {
 			// We are intentionally fetching *all* public keys from the database
 			// here. This allows us to clean up all expired public keys even if
 			// GetAllAsync() is never explicitly called (e.g. when we switch from
@@ -47,7 +47,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			// how GetAllAsync is implemented at the moment, but still.
 			keys = keys.ToList();
 
-			JsonWebKey key = keys.SingleOrDefault( jwk => jwk.Id == id );
+			JsonWebKey key = keys.SingleOrDefault( jwk => jwk.Id.KeyIdEquals( id.ToString() ) );
 
 			return key;
 		}
@@ -74,7 +74,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			return m_inner.SaveAsync( key );
 		}
 
-		Task IPublicKeyDataProvider.DeleteAsync( string id ) {
+		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {
 			return m_inner.DeleteAsync( id );
 		}
 
@@ -91,7 +91,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			if( dt < TimeSpan.FromSeconds( 0 ) ) {
 				await ( this as IPublicKeyDataProvider )
-					.DeleteAsync( key.Id )
+					.DeleteAsync( new Guid( key.Id ) )
 					.SafeAsync();
 				return null;
 			}

--- a/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/ExpiringPublicKeyDataProvider.cs
@@ -70,8 +70,8 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			return keys;
 		}
 
-		Task IPublicKeyDataProvider.SaveAsync( JsonWebKey key ) {
-			return m_inner.SaveAsync( key );
+		Task IPublicKeyDataProvider.SaveAsync( Guid id, JsonWebKey key ) {
+			return m_inner.SaveAsync( id, key );
 		}
 
 		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {

--- a/src/D2L.Security.OAuth2/Keys/Default/LocalPublicKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/LocalPublicKeyProvider.cs
@@ -35,7 +35,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			}
 
 			JsonWebKey jwk = await m_publicKeyDataProvider
-				.GetByIdAsync( id )
+				.GetByIdAsync( new Guid( id ) )
 				.SafeAsync();
 
 			if( jwk != null ) {

--- a/src/D2L.Security.OAuth2/Keys/Default/SavingPrivateKeyProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/SavingPrivateKeyProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using D2L.Services;
 
 namespace D2L.Security.OAuth2.Keys.Default {
@@ -19,7 +20,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			JsonWebKey jwk = result.ToJsonWebKey();
 
-			await m_publicKeyDataProvider.SaveAsync( jwk ).SafeAsync();
+			await m_publicKeyDataProvider.SaveAsync( new Guid( jwk.Id ), jwk ).SafeAsync();
 
 			return result;
 		}

--- a/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
@@ -14,8 +14,8 @@ namespace D2L.Security.OAuth2.Keys.Development {
 	public sealed class InMemoryPublicKeyDataProvider : IPublicKeyDataProvider {
 		private readonly ConcurrentDictionary<string, JsonWebKey> m_keys = new ConcurrentDictionary<string, JsonWebKey>( StringComparer.Ordinal );
 
-		Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( string id ) {
-			if( !m_keys.TryGetValue( id, out JsonWebKey key ) ) {
+		Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( Guid id ) {
+			if( !m_keys.TryGetValue( id.ToString(), out JsonWebKey key ) ) {
 				return Task.FromResult<JsonWebKey>( null );
 			}
 			return Task.FromResult( key );
@@ -35,8 +35,8 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			return Task.Delay( 0 );
 		}
 
-		Task IPublicKeyDataProvider.DeleteAsync( string id ) {
-			m_keys.TryRemove( id, out JsonWebKey removedKey );
+		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {
+			m_keys.TryRemove( id.ToString(), out JsonWebKey removedKey );
 			return Task.Delay( 0 );
 		}
 	}

--- a/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/Development/InMemoryPublicKeyDataProvider.cs
@@ -12,10 +12,10 @@ namespace D2L.Security.OAuth2.Keys.Development {
 	/// </summary>
 	[Obsolete( "Only use this in tests and for prototyping without a db" )]
 	public sealed class InMemoryPublicKeyDataProvider : IPublicKeyDataProvider {
-		private readonly ConcurrentDictionary<string, JsonWebKey> m_keys = new ConcurrentDictionary<string, JsonWebKey>( StringComparer.Ordinal );
+		private readonly ConcurrentDictionary<Guid, JsonWebKey> m_keys = new ConcurrentDictionary<Guid, JsonWebKey>();
 
 		Task<JsonWebKey> IPublicKeyDataProvider.GetByIdAsync( Guid id ) {
-			if( !m_keys.TryGetValue( id.ToString(), out JsonWebKey key ) ) {
+			if( !m_keys.TryGetValue( id, out JsonWebKey key ) ) {
 				return Task.FromResult<JsonWebKey>( null );
 			}
 			return Task.FromResult( key );
@@ -28,15 +28,15 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			return Task.FromResult( result );
 		}
 
-		Task IPublicKeyDataProvider.SaveAsync( JsonWebKey key ) {
-			if( !m_keys.TryAdd( key.Id, key ) ) {
+		Task IPublicKeyDataProvider.SaveAsync( Guid id, JsonWebKey key ) {
+			if( !m_keys.TryAdd( id, key ) ) {
 				throw new InvalidOperationException( "Attempted to add a key twice" );
 			}
 			return Task.Delay( 0 );
 		}
 
 		Task IPublicKeyDataProvider.DeleteAsync( Guid id ) {
-			m_keys.TryRemove( id.ToString(), out JsonWebKey removedKey );
+			m_keys.TryRemove( id, out JsonWebKey removedKey );
 			return Task.Delay( 0 );
 		}
 	}

--- a/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
@@ -25,8 +25,9 @@ namespace D2L.Security.OAuth2.Keys {
 		/// <summary>
 		/// Saves a key
 		/// </summary>
+		/// <param name="id">The key id (kid) of the key to save</param>
 		/// <param name="key">The key to save</param>
-		Task SaveAsync( JsonWebKey key );
+		Task SaveAsync( Guid id, JsonWebKey key );
 
 		/// <summary>
 		/// Deletes a key by key <paramref name="id"/> (kid)

--- a/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/IPublicKeyDataProvider.cs
@@ -14,7 +14,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// </summary>
 		/// <param name="id">The key id (kid)</param>
 		/// <returns>The <see cref="JsonWebKey"/> or null if the key doesn't exist or has expired</returns>
-		Task<JsonWebKey> GetByIdAsync( string id );
+		Task<JsonWebKey> GetByIdAsync( Guid id );
 
 		/// <summary>
 		/// Gets all the <see cref="JsonWebKey"/> instances
@@ -32,7 +32,7 @@ namespace D2L.Security.OAuth2.Keys {
 		/// Deletes a key by key <paramref name="id"/> (kid)
 		/// </summary>
 		/// <param name="id">The key id (kid) of the key to delete</param>
-		Task DeleteAsync( string id );
+		Task DeleteAsync( Guid id );
 
 	}
 }

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/ExpiringPublicKeyDataProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/ExpiringPublicKeyDataProviderTests.cs
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[Test]
 		public async Task GetByIdAsync_EmptyDb_ReturnsNull() {
-			string id = Guid.NewGuid().ToString();
+			var id = Guid.NewGuid();
 			m_mockPublicKeyDataProvider.Setup( kp => kp.GetByIdAsync( id ) ).ReturnsAsync( null );
 
 			JsonWebKey result = await m_publicKeyDataProvider
@@ -55,7 +55,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			AddKeyToDb( key );
 
 
-			string id = Guid.NewGuid().ToString();
+			var id = Guid.NewGuid();
 			m_mockPublicKeyDataProvider.Setup( kp => kp.GetByIdAsync( id ) ).ReturnsAsync( null );
 
 			JsonWebKey result = await m_publicKeyDataProvider
@@ -71,7 +71,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			AddKeyToDb( key );
 
 			JsonWebKey result = await m_publicKeyDataProvider
-				.GetByIdAsync( key.Id )
+				.GetByIdAsync( new Guid( key.Id ) )
 				.SafeAsync();
 
 			Assert.IsNotNull( result );
@@ -82,13 +82,13 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		public async Task GetByIdAsync_ExpiredKey_DeletesAndReturnsNull() {
 			JsonWebKey key = new JsonWebKeyStub( Guid.NewGuid().ToString(), NOW - TimeSpan.FromTicks( 1 ) );
 			AddKeyToDb( key );
-			m_mockPublicKeyDataProvider.Setup( kp => kp.DeleteAsync( key.Id ) ).Returns( Task.Delay( 0 ) );
+			m_mockPublicKeyDataProvider.Setup( kp => kp.DeleteAsync( new Guid( key.Id ) ) ).Returns( Task.Delay( 0 ) );
 
 			JsonWebKey result = await m_publicKeyDataProvider
-				.GetByIdAsync( key.Id )
+				.GetByIdAsync( new Guid( key.Id ) )
 				.SafeAsync();
 
-			m_mockPublicKeyDataProvider.Verify( kp => kp.DeleteAsync( key.Id ), Times.Once() );
+			m_mockPublicKeyDataProvider.Verify( kp => kp.DeleteAsync( new Guid( key.Id ) ), Times.Once() );
 
 			Assert.IsNull( result );
 		}
@@ -100,17 +100,17 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			AddKeyToDb( freshKey );
 			AddKeyToDb( expiredKey );
 			m_mockPublicKeyDataProvider
-				.Setup( pkdb => pkdb.DeleteAsync( expiredKey.Id ) )
+				.Setup( pkdb => pkdb.DeleteAsync( new Guid( expiredKey.Id ) ) )
 				.Returns( Task.Delay( 0 ) );
 
 			JsonWebKey result = await m_publicKeyDataProvider
-				.GetByIdAsync( freshKey.Id )
+				.GetByIdAsync( new Guid( freshKey.Id ) )
 				.SafeAsync();
 
 			Assert.IsNotNull( result );
 			Assert.AreEqual( freshKey.Id, result.Id );
 
-			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.DeleteAsync( expiredKey.Id ), Times.Once );
+			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.DeleteAsync( new Guid( expiredKey.Id ) ), Times.Once );
 		}
 
 		[Test]
@@ -146,7 +146,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			foreach( var id in mehIds ) {
 				var kid = id; // copy the GUID to appease the compiler
 				m_mockPublicKeyDataProvider
-					.Setup( kp => kp.DeleteAsync( kid ) )
+					.Setup( kp => kp.DeleteAsync( new Guid( kid ) ) )
 					.Returns( Task.Delay( 0 ) );
 			}
 
@@ -158,7 +158,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			foreach( var id in mehIds ) {
 				var kid = id; // copy the GUID to appease the compiler
-				m_mockPublicKeyDataProvider.Verify( kp => kp.DeleteAsync( kid ), Times.Once() );
+				m_mockPublicKeyDataProvider.Verify( kp => kp.DeleteAsync( new Guid( kid ) ), Times.Once() );
 			}
 
 			CollectionAssert.AreEquivalent( goodIds, ids );
@@ -167,7 +167,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		private void AddKeyToDb( JsonWebKey key ) {
 			m_allTheKeys.Add( key );
 			m_mockPublicKeyDataProvider
-				.Setup( pkdp => pkdp.GetByIdAsync( key.Id ) )
+				.Setup( pkdp => pkdp.GetByIdAsync( new Guid( key.Id ) ) )
 				.ReturnsAsync( key );
 		}
 	}

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/PrivateKeyProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/PrivateKeyProviderTests.cs
@@ -22,7 +22,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		[SetUp]
 		public void SetUp() {
 			m_mockPublicKeyDataProvider = new Mock<ISanePublicKeyDataProvider>( MockBehavior.Strict );
-			m_mockPublicKeyDataProvider.Setup( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ) ).Returns( Task.Delay( 0 ) );
+			m_mockPublicKeyDataProvider.Setup( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ) ).Returns( Task.Delay( 0 ) );
 
 			m_mockDateTimeProvider = new Mock<IDateTimeProvider>();
 			m_mockDateTimeProvider.Setup( dp => dp.UtcNow ).Returns( () => DateTime.UtcNow );
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		public async Task GetSigningCredentialsAsync_FirstCall_CreatesAndReturnsKey() {
 			D2LSecurityToken key = await m_privateKeyProvider.GetSigningCredentialsAsync().SafeAsync();
 
-			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ), Times.Once() );
+			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ), Times.Once() );
 
 			Assert.NotNull( key );
 		}
@@ -57,7 +57,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 			m_mockDateTimeProvider.Setup( dtp => dtp.UtcNow ).Returns( now + TimeSpan.FromSeconds( offsetSeconds ) );
 			D2LSecurityToken key2 = await m_privateKeyProvider.GetSigningCredentialsAsync().SafeAsync();
 
-			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ), Times.Once() );
+			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ), Times.Once() );
 
 			Assert.AreEqual( key1.KeyId, key2.KeyId );
 		}
@@ -80,7 +80,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			D2LSecurityToken key2 = await m_privateKeyProvider.GetSigningCredentialsAsync().SafeAsync();
 
-			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ), Times.Exactly( 2 ) );
+			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ), Times.Exactly( 2 ) );
 
 			Assert.AreNotEqual( key1.KeyId, key2.KeyId );
 		}
@@ -88,7 +88,7 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		[Test]
 		public async Task GetSigningCredentialsAsync_RaceyFirstCall_CreatesOnlyOneKey() {
 			m_mockPublicKeyDataProvider
-				.Setup( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ) )
+				.Setup( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ) )
 				.Returns( Task.Delay( 100 ) ); // Introduce a delay so that we definitely have some other tasks waiting for the save to complete.
 
 			var tasks = Enumerable
@@ -98,10 +98,10 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 			IEnumerable<D2LSecurityToken> keys = await Task.WhenAll( tasks ).SafeAsync();
 
-			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<JsonWebKey>() ), Times.Once() );
+			m_mockPublicKeyDataProvider.Verify( pkdp => pkdp.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ), Times.Once() );
 			var ids = keys.Select( k => k.KeyId ).ToList();
 			foreach( string id in ids ) {
-				Assert.AreEqual( ids[ 0 ], id );
+				Assert.AreEqual( ids[0], id );
 			}
 		}
 	}

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
@@ -19,7 +19,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_NoKeys_ReturnsNull() {
-			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid().ToString() ).SafeAsync();
+			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid() ).SafeAsync();
 
 			Assert.IsNull( key );
 		}
@@ -29,7 +29,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
 
-			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid().ToString() ).SafeAsync();
+			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid() ).SafeAsync();
 
 			Assert.IsNull( key );
 		}
@@ -39,7 +39,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
 
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt, actualKey.ExpiresAt );
@@ -52,7 +52,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
 
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt, actualKey.ExpiresAt );
@@ -95,15 +95,15 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public void DeleteAsync_MissingKey_DoesntThrow() {
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid().ToString() ).Wait() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid() ).Wait() );
 		}
 
 		[Test]
 		public async Task DeleteAsync_DoesntDeleteOtherKey() {
 			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
 			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid().ToString() ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid() ).Wait() );
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
 
 			Assert.IsNotNull( actualKey );
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
@@ -112,8 +112,8 @@ namespace D2L.Security.OAuth2.Keys.Development {
 		[Test]
 		public async Task DeleteAsync_DoesSeemToDeleteKey() {
 			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
 
 			Assert.IsNull( actualKey );
 		}
@@ -121,9 +121,9 @@ namespace D2L.Security.OAuth2.Keys.Development {
 		[Test]
 		public async Task DeleteAsync_DoubleDelete_DoesSeemToDeleteKey() {
 			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedKey.Id ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedKey.Id ).SafeAsync();
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
 
 			Assert.IsNull( actualKey );
 		}

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Development/InMemoryPublicKeyDataProviderTests.cs
@@ -26,8 +26,9 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_IncorrectId_ReturnsKey() {
-			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
+			var id = Guid.NewGuid();
+			var dummyKey = new JsonWebKeyStub( id.ToString() );
+			await m_publicKeyDataProvider.SaveAsync( id, dummyKey ).SafeAsync();
 
 			var key = await m_publicKeyDataProvider.GetByIdAsync( Guid.NewGuid() ).SafeAsync();
 
@@ -36,10 +37,11 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_CorrectId_ReturnsKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
+			var expectedId = Guid.NewGuid();
+			var expectedKey = new JsonWebKeyStub( expectedId.ToString() );
+			await m_publicKeyDataProvider.SaveAsync( expectedId, expectedKey ).SafeAsync();
 
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedId ).SafeAsync();
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt, actualKey.ExpiresAt );
@@ -47,12 +49,13 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task GetById_CorrectIdWithOthers_ReturnsKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
+			var expectedId = Guid.NewGuid();
+			var expectedKey = new JsonWebKeyStub( expectedId.ToString() );
+			await m_publicKeyDataProvider.SaveAsync( expectedId, expectedKey ).SafeAsync();
 			var dummyKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( dummyKey ).SafeAsync();
+			await m_publicKeyDataProvider.SaveAsync( new Guid( dummyKey.Id ), dummyKey ).SafeAsync();
 
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedId ).SafeAsync();
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt, actualKey.ExpiresAt );
@@ -75,7 +78,7 @@ namespace D2L.Security.OAuth2.Keys.Development {
 			};
 
 			foreach( var key in expected ) {
-				await m_publicKeyDataProvider.SaveAsync( key ).SafeAsync();
+				await m_publicKeyDataProvider.SaveAsync( new Guid( key.Id ), key ).SafeAsync();
 			}
 
 			var actual = await m_publicKeyDataProvider.GetAllAsync().SafeAsync();
@@ -87,10 +90,11 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task SaveAsync_DoubleSave_ThrowsException() {
-			var key = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( key ).SafeAsync();
+			var id = Guid.NewGuid();
+			var key = new JsonWebKeyStub( id.ToString() );
+			await m_publicKeyDataProvider.SaveAsync( id, key ).SafeAsync();
 
-			Assert.Throws<InvalidOperationException>( () => m_publicKeyDataProvider.SaveAsync( key ).Wait() );
+			Assert.Throws<InvalidOperationException>( () => m_publicKeyDataProvider.SaveAsync( id, key ).Wait() );
 		}
 
 		[Test]
@@ -100,10 +104,11 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task DeleteAsync_DoesntDeleteOtherKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			await m_publicKeyDataProvider.SaveAsync( expectedKey ).SafeAsync();
+			var expectedId = Guid.NewGuid();
+			var expectedKey = new JsonWebKeyStub( expectedId.ToString() );
+			await m_publicKeyDataProvider.SaveAsync( expectedId, expectedKey ).SafeAsync();
 			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( Guid.NewGuid() ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedId ).SafeAsync();
 
 			Assert.IsNotNull( actualKey );
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
@@ -111,19 +116,21 @@ namespace D2L.Security.OAuth2.Keys.Development {
 
 		[Test]
 		public async Task DeleteAsync_DoesSeemToDeleteKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
+			var expectedId = Guid.NewGuid();
+			var expectedKey = new JsonWebKeyStub( expectedId.ToString() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedId ).Wait() );
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedId ).SafeAsync();
 
 			Assert.IsNull( actualKey );
 		}
 
 		[Test]
 		public async Task DeleteAsync_DoubleDelete_DoesSeemToDeleteKey() {
-			var expectedKey = new JsonWebKeyStub( Guid.NewGuid().ToString() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
-			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( new Guid( expectedKey.Id ) ).Wait() );
-			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( new Guid( expectedKey.Id ) ).SafeAsync();
+			var expectedId = Guid.NewGuid();
+			var expectedKey = new JsonWebKeyStub( expectedId.ToString() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedId ).Wait() );
+			Assert.DoesNotThrow( () => m_publicKeyDataProvider.DeleteAsync( expectedId ).Wait() );
+			var actualKey = await m_publicKeyDataProvider.GetByIdAsync( expectedId ).SafeAsync();
 
 			Assert.IsNull( actualKey );
 		}


### PR DESCRIPTION
Reverts the `IPublicKeyDataProvider` back to Guid ids as string is not
required on this interface, only used by D2L/AuthService.