### PR TITLE
Allow private keys to be stored and rotated externally.

### DIFF
--- a/src/D2L.Security.OAuth2/IsExternalInit.net4x.cs
+++ b/src/D2L.Security.OAuth2/IsExternalInit.net4x.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// From: https://github.com/dotnet/runtime/commit/6072e4d3a7a2a1493f514cdf4be75a3d56580e84#diff-afc57cc6e9c659ebf491bc78d06cdb5b13d5a049122d8a41f744a515f493663b
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices {
+	/// <summary>
+	/// Reserved to be used by the compiler for tracking metadata.
+	/// This class should not be used by developers in source code.
+	/// </summary>
+	[EditorBrowsable( EditorBrowsableState.Never )]
+	internal static class IsExternalInit {
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/IKeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/IKeyManagementService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace D2L.Security.OAuth2.Keys {
+	public interface IKeyManagementService {
+		/// <summary>
+		/// Generates a new key (storing it's public and private keys) if the
+		/// existing ones are getting near their expiry.
+		///
+		/// You would call this in a background job on a regular + frequent
+		/// cadence.
+		/// </summary>
+		Task GenerateNewKeyIfNeededAsync();
+
+		/// <summary>
+		/// Causes the key manager to go looking for a new private key from the
+		/// key store.
+		/// </summary>
+		/// <returns>
+		/// The amount of time to wait before calling this again.
+		/// </returns>
+		Task<TimeSpan> RefreshKeyAsync();
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/IPrivateKeyDataProvider.cs
+++ b/src/D2L.Security.OAuth2/Keys/IPrivateKeyDataProvider.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace D2L.Security.OAuth2.Keys {
+	/// <summary>
+	/// An externally-implemented storage for private keys.
+	/// </summary>
+	public interface IPrivateKeyDataProvider {
+		/// <summary>
+		/// Save a private key.
+		/// </summary>
+		Task SaveAsync( PrivateKeyData keyData );
+
+		/// <summary>
+		/// Gets all non-expiring private keys.
+		/// </summary>
+		/// <param name="validUntilAtLeast">The earliest possible expiry time toreturn (should be in the future.)</param>
+		/// <returns>All non-expired/expiring private keys</returns>
+		Task<IEnumerable<PrivateKeyData>> GetAllAsync(
+			DateTimeOffset validUntilAtLeast
+		);
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
@@ -96,9 +96,10 @@ namespace D2L.Security.OAuth2.Keys {
 			var keyId = Guid.NewGuid();
 			var keyIdStr = keyId.ToString();
 
-			using var csp = new RSACryptoServiceProvider {
+			using var csp = new RSACryptoServiceProvider( Constants.GENERATED_RSA_KEY_SIZE ) {
 				PersistKeyInCsp = false
 			};
+
 
 			var pub = csp.ExportParameters(
 				includePrivateParameters: false

--- a/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
@@ -1,0 +1,207 @@
+﻿using D2L.Security.OAuth2.Keys.Default;
+using D2L.Security.OAuth2.Utilities;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace D2L.Security.OAuth2.Keys {
+	internal sealed class KeyManagementService : IKeyManagementService, IPrivateKeyProvider, IDisposable {
+		private readonly IPublicKeyDataProvider m_publicKeys;
+		private readonly IPrivateKeyDataProvider m_privateKeys;
+		private readonly IDateTimeProvider m_clock;
+		private readonly OAuth2Configuration m_config;
+
+		private D2LSecurityToken m_current = null;
+
+		public KeyManagementService(
+			IPublicKeyDataProvider publicKeys,
+			IPrivateKeyDataProvider privateKeys,
+			IDateTimeProvider clock,
+			OAuth2Configuration config
+		) {
+			m_publicKeys = publicKeys;
+			m_privateKeys = privateKeys;
+			m_clock = clock;
+			m_config = config;
+		}
+
+		async Task<D2LSecurityToken> IPrivateKeyProvider.GetSigningCredentialsAsync() {
+			var current = Volatile.Read( ref m_current );
+
+			var now = m_clock.UtcNow;
+
+			if ( current == null || current.ValidTo <= now ) {
+				// Slow path: RefreshKeyAsync() wasn't called on boot and/or it
+				// isn't being called in a background job.
+				await RefreshKeyAsync( current, now )
+					.ConfigureAwait( false );
+
+				current = Volatile.Read( ref m_current );
+			}
+
+			return current.Ref();
+		}
+
+		async Task<TimeSpan> IKeyManagementService.RefreshKeyAsync() {
+			var current = Volatile.Read( ref m_current );
+
+			var now = m_clock.UtcNow;
+
+			await RefreshKeyAsync(
+				current,
+				now
+			).ConfigureAwait( false );
+
+			current = Volatile.Read( ref m_current );
+
+			var expectedNextRotation = current.ValidTo - m_config.KeyRotationBuffer;
+
+			if( now > expectedNextRotation ) {
+				// If that's in the past, use a short retry window.
+				return TimeSpan.FromSeconds( 10 );
+			} else {
+				// Otherwise use that but with a little buffer for key
+				// generation time/imprecisely scheduled cron jobs.
+				return expectedNextRotation.AddMinutes( 1 ) - now;
+			}
+		}
+
+		async Task IKeyManagementService.GenerateNewKeyIfNeededAsync() {
+			var now = m_clock.UtcNow;
+
+			var keys = await m_privateKeys.GetAllAsync(
+				validUntilAtLeast: now
+			).ConfigureAwait( false );
+
+			foreach( var key in keys ) {
+				if( now < key.ExpiresAt - m_config.KeyRotationBuffer ) {
+					// This key is fine, do nothing.
+					return;
+				}
+			}
+
+			var keyId = Guid.NewGuid();
+			var keyIdStr = keyId.ToString();
+
+			using var csp = new RSACryptoServiceProvider {
+				PersistKeyInCsp = false
+			};
+
+			var pub = csp.ExportParameters(
+				includePrivateParameters: false
+			);
+
+			var priv = csp.ExportCspBlob(
+				includePrivateParameters: true
+			);
+
+			var expiresAt = now + m_config.KeyLifetime;
+
+			await Task.WhenAll(
+				m_publicKeys.SaveAsync(
+					keyId,
+					new RsaJsonWebKey(
+						keyIdStr,
+						expiresAt,
+						pub
+					)
+				),
+				m_privateKeys.SaveAsync(
+					new PrivateKeyData(
+						id: keyIdStr,
+						kind: PrivateKeyData.KeyKinds.Rsa,
+						data: priv,
+						createdAt: now,
+						notBefore: now + m_config.KeyTimeUntilUse,
+						expiresAt: expiresAt
+					)
+				)
+			).ConfigureAwait( false );
+		}
+
+		private async Task RefreshKeyAsync(
+			D2LSecurityToken current,
+			DateTimeOffset now
+		) {
+			var keys = await m_privateKeys.GetAllAsync(
+				validUntilAtLeast: now
+			).ConfigureAwait( continueOnCapturedContext: false );
+
+			var best = ChooseKey( keys, now ).Ref();
+
+			var loser = Interlocked.CompareExchange(
+				ref m_current,
+				best,
+				comparand: current
+			);
+
+			loser?.Dispose();
+		}
+
+		private D2LSecurityToken ChooseKey(
+			IEnumerable<PrivateKeyData> keys,
+			DateTimeOffset now
+		) {
+			PrivateKeyData candidate = null;
+
+			foreach( var key in keys ) {
+				// Ignore unsupported key types
+				if( key.Kind != PrivateKeyData.KeyKinds.Rsa ) {
+					continue;
+				}
+
+				// Use any non-expired key if it's the only one
+				if( candidate == null ) {
+					candidate = key;
+					continue;
+				}
+
+				if( candidate.NotBefore > now && key.NotBefore <= now ) {
+					// If we can switch to a key past its NotBefore, do that.
+					candidate = key;
+				} else if( candidate.NotBefore > now && candidate.CreatedAt > key.CreatedAt ) {
+					// When comparing two keys that are not past their respective
+					// NotBefore points, prefer the oldest one.
+					candidate = key;
+				} else if ( candidate.NotBefore <= now && key.NotBefore <= now && candidate.ExpiresAt < key.ExpiresAt ) {
+					// If we have two keys past their NotBefore date, pick the
+					// one that expires the latest.
+					candidate = key;
+				}
+			}
+
+			Func<Tuple<AsymmetricSecurityKey, IDisposable>> keyFactory = candidate.Kind switch {
+				PrivateKeyData.KeyKinds.Rsa => () => {
+					var csp = new RSACryptoServiceProvider {
+						PersistKeyInCsp = false
+					};
+
+					csp.ImportCspBlob( candidate.Data );
+
+					var key = new RsaSecurityKey( csp );
+
+					return new(key, csp);
+				},
+				_ => throw new NotImplementedException()
+			};
+
+			return new D2LSecurityToken(
+				id: candidate.Id,
+				validFrom: candidate.CreatedAt,
+				validTo: candidate.ExpiresAt,
+				keyFactory
+			);
+		}
+
+		private readonly object m_disposeLock = new();
+
+		public void Dispose() {
+			lock( m_disposeLock ) {
+				m_current?.Dispose();
+			}
+		}
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
@@ -162,9 +162,9 @@ namespace D2L.Security.OAuth2.Keys {
 					// When comparing two keys that are not past their respective
 					// NotBefore points, prefer the oldest one.
 					candidate = key;
-				} else if ( candidate.NotBefore <= now && key.NotBefore <= now && candidate.ExpiresAt < key.ExpiresAt ) {
+				} else if ( candidate.NotBefore <= now && key.NotBefore <= now && candidate.CreatedAt < key.CreatedAt ) {
 					// If we have two keys past their NotBefore date, pick the
-					// one that expires the latest.
+					// one that was created most recently.
 					candidate = key;
 				}
 			}
@@ -192,12 +192,8 @@ namespace D2L.Security.OAuth2.Keys {
 			);
 		}
 
-		private readonly object m_disposeLock = new();
-
 		public void Dispose() {
-			lock( m_disposeLock ) {
-				m_current?.Dispose();
-			}
+			m_current?.Dispose();
 		}
 	}
 }

--- a/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
@@ -132,13 +132,9 @@ namespace D2L.Security.OAuth2.Keys {
 
 			var best = ChooseKey( keys, now ).Ref();
 
-			var loser = Interlocked.CompareExchange(
-				ref m_current,
-				best,
-				comparand: current
-			);
+			var prev = Interlocked.Exchange( ref m_current, best );
 
-			loser?.Dispose();
+			prev?.Dispose();
 		}
 
 		private D2LSecurityToken ChooseKey(

--- a/src/D2L.Security.OAuth2/Keys/PrivateKeyData.cs
+++ b/src/D2L.Security.OAuth2/Keys/PrivateKeyData.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace D2L.Security.OAuth2.Keys {
+	public sealed class PrivateKeyData {
+		internal static class KeyKinds {
+			public const string Rsa = "rsa";
+			public const string Ecdsa = "ecdsa";
+		}
+
+		public PrivateKeyData(
+			string id,
+			string kind,
+			byte[] data,
+			DateTimeOffset createdAt,
+			DateTimeOffset notBefore,
+			DateTimeOffset expiresAt
+		) {
+			Id = id;
+			Kind = kind;
+			Data = data;
+			CreatedAt = createdAt;
+			NotBefore = notBefore;
+			ExpiresAt = expiresAt;
+		}
+
+		/// <summary>
+		/// The jwk "key id"/kid.
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// The kind of key (e.g. RSA)
+		/// </summary>
+		public string Kind { get; }
+
+		/// <summary>
+		/// Kind-specific key data (including the private bits.)
+		/// </summary>
+		public byte[] Data { get; }
+
+		/// <summary>
+		/// The time the key was originally created.
+		/// </summary>
+		public DateTimeOffset CreatedAt { get; }
+
+		/// <summary>
+		/// The key should not be used to sign things before this point. The
+		/// gap between CreatedAt and NotBefore allows for jwks caches to
+		/// expire and gives opportunity for people to fetch our new key in the
+		/// background.
+		//
+		/// If there are no other keys available in an emergency it is okay
+		/// to sign messages with a key that has not reached NotBefore.
+		/// </summary>
+		public DateTimeOffset NotBefore { get; }
+
+		/// <summary>
+		/// Once a key is expired nothing signed by it will validate.
+		/// </summary>
+		public DateTimeOffset ExpiresAt { get; }
+	}
+}

--- a/src/D2L.Security.OAuth2/Keys/PrivateKeyData.cs
+++ b/src/D2L.Security.OAuth2/Keys/PrivateKeyData.cs
@@ -58,5 +58,14 @@ namespace D2L.Security.OAuth2.Keys {
 		/// Once a key is expired nothing signed by it will validate.
 		/// </summary>
 		public DateTimeOffset ExpiresAt { get; }
+
+		public bool WouldPreferToRotate( DateTimeOffset now, TimeSpan rotationBuffer )
+			=> now >= ExpiresAt - rotationBuffer;
+
+		public bool IsPastNotBefore( DateTimeOffset now )
+			=> now >= NotBefore;
+
+		public bool IsExpired( DateTimeOffset now )
+			=> now >= ExpiresAt;
 	}
 }

--- a/src/D2L.Security.OAuth2/OAuth2Configuration.cs
+++ b/src/D2L.Security.OAuth2/OAuth2Configuration.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace D2L.Security.OAuth2 {
+	public sealed class OAuth2Configuration {
+		/// <summary>
+		/// When a new key is created we try to avoid using it immediately so
+		/// that caches can expire.
+		/// </summary>
+		public TimeSpan KeyTimeUntilUse { get; init; }
+			= TimeSpan.FromHours( 1 );
+
+		/// <summary>
+		/// We rotate keys before they expire so that any tokens signed by the
+		/// key will become invalid before it expires.
+		/// </summary>
+		public TimeSpan KeyRotationBuffer { get; init; }
+			= TimeSpan.FromDays( 7 );
+
+		/// <summary>
+		/// The total lifetime keys we generate.
+		/// </summary>
+		public TimeSpan KeyLifetime { get; init; }
+			= TimeSpan.FromDays( 30 );
+
+		/// <summary>
+		/// Check that the settings make sense and enforce some minimums to
+		/// make reasoning about details around rotation easier.
+		/// </summary>
+		internal void CheckSanity() {
+			if( KeyTimeUntilUse.TotalHours < 1 ) {
+				throw new Exception( "KeyTimeUntilUse is too short" );
+			}
+
+			if( KeyTimeUntilUse >= KeyLifetime ) {
+				throw new Exception( "KeyTimeUntilUse is too long" );
+			}
+
+			if( KeyRotationBuffer.TotalHours < 1 ) {
+				throw new Exception( "KeyRotationBuffer is too short" );
+			}
+
+			if( KeyRotationBuffer >= KeyLifetime ) {
+				throw new Exception( "KeyRotationBuffer is too long" );
+			}
+
+			if( KeyLifetime.TotalHours < 3 ) {
+				throw new Exception( "KeyLifetime is too short" );
+			}
+
+			if( KeyLifetime.TotalDays > 365 ) {
+				throw new Exception( "KeyLifetime is too long" );
+			}
+
+			if( (KeyLifetime - KeyRotationBuffer - KeyTimeUntilUse).TotalHours < 1 ) {
+				throw new Exception( "KeyLifetime should be long enough to avoid rotations for at least an hour" );
+			}
+		}
+	}
+}

--- a/src/D2L.Security.OAuth2/OAuth2Factory.cs
+++ b/src/D2L.Security.OAuth2/OAuth2Factory.cs
@@ -1,0 +1,38 @@
+﻿using D2L.Security.OAuth2.Keys;
+using D2L.Security.OAuth2.Keys.Default;
+using D2L.Security.OAuth2.Utilities;
+
+namespace D2L.Security.OAuth2 {
+	public static class OAuth2Factory {
+		/// <summary>
+		/// Create an IKeyManagmentService and ITokenSigner given key storage
+		/// and configuration.
+		/// </summary>
+		public static void Create(
+			IPublicKeyDataProvider publicKeyDataProvider,
+			IPrivateKeyDataProvider privateKeyDataProvider,
+
+			out IKeyManagementService keyManagementService,
+			out ITokenSigner tokenSigner,
+
+			OAuth2Configuration config = null
+		) {
+			config = config ?? new OAuth2Configuration();
+
+			config.CheckSanity();
+
+			var clock = new DateTimeProvider();
+
+			keyManagementService = new KeyManagementService(
+				publicKeyDataProvider,
+				privateKeyDataProvider,
+				clock,
+				config
+			);
+
+			tokenSigner = new TokenSigner(
+				keyManagementService as IPrivateKeyProvider
+			);
+		}
+	}
+}

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
@@ -214,7 +214,7 @@ namespace D2L.Security.OAuth2.UnitTests.Keys.Default {
 
 			UsePrivateKeys( key );
 
-			await m_kms.RefreshKeyAsync();
+			await m_kms.GenerateNewKeyIfNeededAsync();
 
 			// If it were to generate a new key it would have to save it which
 			// would trigger our strict mocks.

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
@@ -120,13 +120,11 @@ namespace D2L.Security.OAuth2.UnitTests.Keys.Default {
 		}
 
 		[Test]
-		public async Task GetSigningCredentialsAsync_TwoActiveKeys_PrefersNewest() {
+		public async Task GetSigningCredentialsAsync_OnBoot_TwoActiveKeys_PrefersNewest() {
 			var oldActive = CreateActiveKey();
 			var newActive = CreateNewActiveKey();
 
 			UsePrivateKeys( oldActive, newActive );
-
-			await m_kms.RefreshKeyAsync();
 
 			using var creds = await m_pkp.GetSigningCredentialsAsync();
 

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/Default/KeyManagementServiceTests.cs
@@ -1,0 +1,377 @@
+﻿using D2L.Security.OAuth2.Keys;
+using D2L.Security.OAuth2.Keys.Default;
+using D2L.Security.OAuth2.Utilities;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace D2L.Security.OAuth2.UnitTests.Keys.Default {
+	[TestFixture]
+	internal sealed class KeyManagementServiceTests {
+		private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+		private static TimeSpan ALittleBit = TimeSpan.FromMinutes( 30 );
+
+		private static readonly OAuth2Configuration KeyConfig = new() {
+			// First hour: the key ages (to allow time for caches to flush)
+			// Second hour: the key is used exclusively
+			// Third hour: we generate a new key but don't use it
+			// Forth hour: we switch to the new key
+			// Fifth hour: the old key is now expired
+			// ....
+			KeyLifetime = TimeSpan.FromHours( 4 ),
+			KeyTimeUntilUse = TimeSpan.FromHours( 1 ),
+			KeyRotationBuffer = TimeSpan.FromHours( 2 )
+		};
+
+		private Mock<IPublicKeyDataProvider> m_publicKeys;
+		private Mock<IPrivateKeyDataProvider> m_privateKeys;
+		private Mock<IDateTimeProvider> m_clock;
+
+		private IKeyManagementService m_kms;
+		private IPrivateKeyProvider m_pkp;
+		private IDisposable m_disposable;
+
+		[SetUp]
+		public void SetUp() {
+			m_publicKeys = new( MockBehavior.Strict );
+			m_privateKeys = new( MockBehavior.Strict );
+			m_clock = new( MockBehavior.Strict );
+
+			SetClock( Now );
+
+			var kms = new KeyManagementService(
+				m_publicKeys.Object,
+				m_privateKeys.Object,
+				m_clock.Object,
+				KeyConfig
+			);
+
+			m_kms = kms;
+			m_pkp = kms;
+			m_disposable = kms;
+		}
+
+		[TearDown]
+		public void TearDown() {
+			m_disposable.Dispose();
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_OnBoot_NewKey_UsesIt() {
+			var key = CreateNewKey();
+
+			UsePrivateKeys( key );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( key, creds );
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_OnBoot_ActiveKey_UsesIt() {
+			var key = CreateActiveKey();
+
+			UsePrivateKeys( key );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( key, creds );
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_OnBoot_OldKey_UsesIt() {
+			var key = CreateOldKey();
+
+			UsePrivateKeys( key );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( key, creds );
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_OnBoot_ExpiredKey_ReturnsNull() {
+			var key = CreateExpiredKey();
+
+			UsePrivateKeys( key );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			Assert.IsNull( creds );
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_HasNewKeyCached_SticksToIt() {
+			var firstKey = CreateNewKey();
+
+			await PrimeCacheAsync( firstKey );
+
+			// It would be "better" to use this, but GetSigningCredentialsAsync()
+			// won't go looking. RefreshAsync() is used to do that out-of-band.
+			var secondKey = CreateActiveKey();
+
+			UsePrivateKeys( firstKey, secondKey );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( firstKey, creds );
+		}
+
+		[Test]
+		public async Task GetSigningCredentialsAsync_TwoActiveKeys_PrefersNewest() {
+			var oldActive = CreateActiveKey();
+			var newActive = CreateNewActiveKey();
+
+			UsePrivateKeys( oldActive, newActive );
+
+			await m_kms.RefreshKeyAsync();
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( newActive, creds );
+		}
+
+		[Test]
+		public async Task RefreshAsync_HasNewKeyCached_ReplacesWithActiveKey() {
+			var firstKey = CreateNewKey();
+
+			await PrimeCacheAsync( firstKey );
+
+			var secondKey = CreateActiveKey();
+
+			UsePrivateKeys( firstKey, secondKey );
+
+			var actualDt = await m_kms.RefreshKeyAsync();
+
+			// RefreshAsync chooses an active key and tells the caller they
+			// don't need to call back until a minute after a rotation should
+			// have happened
+			Assert.AreEqual(
+				// Time until we generate a new key
+				ALittleBit
+				// Time until that key is active
+				+ KeyConfig.KeyTimeUntilUse
+				// Wiggle room
+				+ TimeSpan.FromMinutes( 1 ),
+				actualDt
+			);
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( secondKey, creds );
+		}
+
+		[Test]
+		public async Task RefreshAsync_HasVeryNewKeyCached_ReplacesWithLessNewKey() {
+			var firstKey = CreateVeryNewKey();
+
+			await PrimeCacheAsync( firstKey );
+
+			var secondKey = CreateNewKey();
+
+			UsePrivateKeys( firstKey, secondKey );
+
+			await m_kms.RefreshKeyAsync();
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			// We prefer the oldest key in this case because it is the least
+			// likely to cause cache problems
+			AssertCorrectKey( secondKey, creds );
+		}
+
+		[Test]
+		public async Task RefreshAsync_HasVeryOldKeyCached_NoNewKeys_SaysRetrySoon() {
+			var key = CreateVeryOldKey();
+
+			await PrimeCacheAsync( key );
+
+			var actualDt = await m_kms.RefreshKeyAsync();
+
+			Assert.AreEqual( TimeSpan.FromMinutes( 1 ), actualDt );
+		}
+
+		[Test]
+		public async Task RefreshAsync_NoKeys_SaysRetryVerySoon() {
+			UsePrivateKeys();
+
+			var actualDt = await m_kms.RefreshKeyAsync();
+
+			Assert.AreEqual( TimeSpan.FromSeconds( 10 ), actualDt );
+
+			// Double check that we didn't cache anything
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			Assert.IsNull( creds );
+		}
+
+		[Test]
+		public async Task GenerateNewKeyIfNeededAsync_HasActiveKey_DoesNothing() {
+			var key = CreateActiveKey();
+
+			UsePrivateKeys( key );
+
+			await m_kms.RefreshKeyAsync();
+
+			// If it were to generate a new key it would have to save it which
+			// would trigger our strict mocks.
+		}
+
+		[Test]
+		public async Task GenerateNewKeyIfNeededAsync_HasNewKey_DoesNothing() {
+			var key = CreateNewKey();
+
+			UsePrivateKeys( key );
+
+			// Although we'd prefer to use an older key, generating a new one
+			// couldn't help: the reason NotBefore exists is to give time for
+			// caches to expire, and generating a new key (even with an
+			// artificially in-the-past NotBefore) can't change that.
+
+			await m_kms.GenerateNewKeyIfNeededAsync();
+
+			// Again, relying on strict mocks.
+		}
+
+		[Test]
+		public async Task GenerateNewKeyIfNeededAsync_NoKey_GeneratesOne() {
+			UsePrivateKeys();
+
+			ExpectNewKey();
+
+			await m_kms.GenerateNewKeyIfNeededAsync();
+
+			VerifyNewKeyWasSaved();
+		}
+
+		[Test]
+		public async Task GenerateNewKeyIfNeededAsync_OldKey_GeneratesOne() {
+			var key = CreateOldKey();
+
+			UsePrivateKeys( key );
+
+			ExpectNewKey();
+
+			await m_kms.GenerateNewKeyIfNeededAsync();
+
+			VerifyNewKeyWasSaved();
+		}
+
+		private void ExpectNewKey() {
+			m_publicKeys.Setup( pub => pub.SaveAsync( It.IsAny<Guid>(), It.IsAny<JsonWebKey>() ) )
+				.Returns( Task.CompletedTask )
+				.Verifiable();
+
+			m_privateKeys.Setup( priv => priv.SaveAsync( It.IsAny<PrivateKeyData>() ) )
+				.Returns( Task.CompletedTask )
+				.Verifiable();
+		}
+
+		private void VerifyNewKeyWasSaved() {
+			m_publicKeys.VerifyAll();
+			m_privateKeys.VerifyAll();
+		}
+
+		private async Task PrimeCacheAsync( PrivateKeyData key ) {
+			UsePrivateKeys( key );
+
+			using var creds = await m_pkp.GetSigningCredentialsAsync();
+
+			AssertCorrectKey( key, creds );
+		}
+
+		private void AssertCorrectKey( PrivateKeyData expected, D2LSecurityToken actual ) {
+			Assert.IsNotNull( actual );
+			Assert.AreEqual( expected.Id, actual.Id );
+		}
+
+		private void SetClock( DateTimeOffset t )
+			=> m_clock.Setup( c => c.UtcNow ).Returns( t );
+
+		private void UsePrivateKeys( params PrivateKeyData[] keys ) {
+			m_privateKeys.Setup( pkp => pkp.GetAllAsync( Now ) )
+				.ReturnsAsync( keys );
+		}
+
+		private PrivateKeyData CreateVeryNewKey() {
+			var key = CreateKey( Now );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsFalse( key.IsPastNotBefore( Now ) );
+			Assert.IsFalse( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateNewKey() {
+			var key = CreateKey( Now - ALittleBit );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsFalse( key.IsPastNotBefore( Now ) );
+			Assert.IsFalse( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateNewActiveKey() {
+			var key = CreateKey( Now - KeyConfig.KeyTimeUntilUse - TimeSpan.FromSeconds( 1 ) );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsTrue( key.IsPastNotBefore( Now ) );
+			Assert.IsFalse( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateActiveKey() {
+			var key = CreateKey( Now - KeyConfig.KeyTimeUntilUse - ALittleBit );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsTrue( key.IsPastNotBefore( Now ) );
+			Assert.IsFalse( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateOldKey() {
+			var key = CreateKey( Now - KeyConfig.KeyRotationBuffer - ALittleBit );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsTrue( key.IsPastNotBefore( Now ) );
+			Assert.IsTrue( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateVeryOldKey() {
+			var key = CreateKey( Now - KeyConfig.KeyLifetime + ALittleBit );
+
+			Assert.IsFalse( key.IsExpired( Now ) );
+			Assert.IsTrue( key.IsPastNotBefore( Now ) );
+			Assert.IsTrue( key.WouldPreferToRotate( Now, KeyConfig.KeyRotationBuffer ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateExpiredKey() {
+			var key = CreateKey( Now - KeyConfig.KeyLifetime );
+
+			Assert.IsTrue( key.IsExpired( Now ) );
+
+			return key;
+		}
+
+		private PrivateKeyData CreateKey( DateTimeOffset createdAt )
+			=> new(
+				id: Guid.NewGuid().ToString(),
+				kind: PrivateKeyData.KeyKinds.Rsa,
+				data: null,
+				createdAt: createdAt,
+				notBefore: createdAt + KeyConfig.KeyTimeUntilUse,
+				expiresAt: createdAt + KeyConfig.KeyLifetime
+			);
+	}
+}


### PR DESCRIPTION
External storage (vs. in-memory) will work better for scale-up/scale-down activity. This will enable us to scale more aggressively, including use-cases like AWS Lambda.

It also moves rotation out-of-line of requests, which will avoid CPU+latency spikes.

Fetching the latest private key will still be done on-demand, but there is the option to do it proactively out-of-band. This will allow us to consolidate the fetch in web-server workloads and further hide latency from individual requests.

Web server workloads will be able to proactively fetch a key on boot before being placed into load.