### PR TITLE
Remove some .NET Framework references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<ItemGroup>
-    	<PackageVersion  Include="BenchmarkDotNet" Version="0.13.1" />
+		<PackageVersion  Include="BenchmarkDotNet" Version="0.13.1" />
 		<PackageVersion  Include="D2L.CodeStyle.Analyzers" Version="0.188.0" />
 		<PackageVersion  Include="D2L.CodeStyle.Annotations" Version="0.31.0" />
 		<PackageVersion  Include="D2L.Services.Core.Exceptions" Version="2.0.1.15" />
@@ -17,6 +17,7 @@
 		<PackageVersion  Include="SimpleLogInterface" Version="3.0.1" />
 		<PackageVersion  Include="System.Collections.Immutable" Version="6.0.0" />
 		<PackageVersion  Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
+		<PackageVersion  Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion  Include="System.Text.Json" Version="6.0.2" />
 	</ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<ItemGroup>
-		<PackageVersion  Include="BenchmarkDotNet" Version="0.13.1" />
+    	<PackageVersion  Include="BenchmarkDotNet" Version="0.13.1" />
 		<PackageVersion  Include="D2L.CodeStyle.Analyzers" Version="0.188.0" />
 		<PackageVersion  Include="D2L.CodeStyle.Annotations" Version="0.31.0" />
 		<PackageVersion  Include="D2L.Services.Core.Exceptions" Version="2.0.1.15" />
@@ -17,7 +17,6 @@
 		<PackageVersion  Include="SimpleLogInterface" Version="3.0.1" />
 		<PackageVersion  Include="System.Collections.Immutable" Version="6.0.0" />
 		<PackageVersion  Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
-		<PackageVersion  Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion  Include="System.Text.Json" Version="6.0.2" />
 	</ItemGroup>
 </Project>

--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -19,6 +19,7 @@
 		<PackageReference Include="D2L.Services.Core.Exceptions" />
 		<PackageReference Include="System.Collections.Immutable" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+		<PackageReference Include="System.Net.Http" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">
@@ -32,8 +33,6 @@
 		<!-- We use System.Text.Json in .NET 5+ -->
 		<PackageReference Include="Newtonsoft.Json" />
 
-		<Reference Include="System.IdentityModel" />
-		<Reference Include="System.Net.Http" />
 		<Reference Include="System.Web" />
 	</ItemGroup>
 

--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -19,7 +19,6 @@
 		<PackageReference Include="D2L.Services.Core.Exceptions" />
 		<PackageReference Include="System.Collections.Immutable" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-		<PackageReference Include="System.Net.Http" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">
@@ -33,6 +32,7 @@
 		<!-- We use System.Text.Json in .NET 5+ -->
 		<PackageReference Include="Newtonsoft.Json" />
 
+		<Reference Include="System.Net.Http" />
 		<Reference Include="System.Web" />
 	</ItemGroup>
 


### PR DESCRIPTION
This removes `System.IdentityModel` which wasn't being referenced anywhere

The motivation for doing this: We want to remove `System.IdentityModel` from the LMS (well all `References`) in our transition to .NET. However I have been noticing certain projects building that use classes in `System.IdentityModel` but don't reference `System.IdentityModel`. We think it's because it's picking up `System.IdentityModel` as a transitive dependency. For example, [D2L.LP.Auth](https://github.com/Brightspace/lms/blob/master/platformTools/auth/D2L.LP.Auth/D2L.LP.Auth.csproj#L24) depends on this package as well as `System.IdentityModel`. Even though I remove `System.IdentityModel` reference, the project still compiles :(