### PR TITLE
Reject RSA JSON key whose modulus has 0 byte prefix

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/Default/RsaJsonWebKey.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/RsaJsonWebKey.cs
@@ -30,16 +30,44 @@ namespace D2L.Security.OAuth2.Keys.Default {
 		/// </summary>
 		/// <param name="id">The key id (kid)</param>
 		/// <param name="expiresAt">When the key expires</param>
+		/// <param name="modulus">The RSA modulus</param>
+		/// <param name="exponent">The RSA exponent</param>
+		private RsaJsonWebKey(
+			string id,
+			DateTimeOffset? expiresAt,
+			byte[] modulus,
+			byte[] exponent
+		) : base( id, expiresAt ) {
+			m_parameters.Modulus = modulus;
+			m_parameters.Exponent = exponent;
+		}
+
+		/// <summary>
+		/// Tries to parse parameters into a new <see cref="RsaJsonWebKey"/> instance
+		/// </summary>
+		/// <param name="id">The key id (kid)</param>
+		/// <param name="expiresAt">When the key expires</param>
 		/// <param name="n">The RSA modulus</param>
 		/// <param name="e">The RSA exponent</param>
-		public RsaJsonWebKey(
+		/// <param name="rsaJsonWebKey">The parsed <see cref="RsaJsonWebKey"/> instance</param>
+		/// <returns>true if the key was successfully parsed, or false if the decoded RSA modulus starts with a 0 byte</returns>
+		public static bool TryParse(
 			string id,
 			DateTimeOffset? expiresAt,
 			string n,
-			string e
-		) : base( id, expiresAt ) {
-			m_parameters.Modulus = Base64UrlEncoder.DecodeBytes( n );
-			m_parameters.Exponent = Base64UrlEncoder.DecodeBytes( e );
+			string e,
+			out RsaJsonWebKey rsaJsonWebKey
+		) {
+			var modulus = Base64UrlEncoder.DecodeBytes( n );
+			var exponent = Base64UrlEncoder.DecodeBytes( e );
+
+			if( modulus.Length > 0 && modulus[0] == 0 ) {
+				rsaJsonWebKey = default;
+				return false;
+			}
+
+			rsaJsonWebKey = new RsaJsonWebKey( id, expiresAt, modulus, exponent );
+			return true;
 		}
 
 		/// <summary>

--- a/src/D2L.Security.OAuth2/Keys/JsonWebKey.cs
+++ b/src/D2L.Security.OAuth2/Keys/JsonWebKey.cs
@@ -104,12 +104,17 @@ namespace D2L.Security.OAuth2.Keys {
 						throw new JsonWebKeyParseException( "RSA JSON web key has private key material" );
 					}
 
-					return new RsaJsonWebKey(
+					if( !RsaJsonWebKey.TryParse(
 						id: id,
 						expiresAt: expiresAt,
-						n: data[ "n" ].ToString(),
-						e: data[ "e" ].ToString()
-					);
+						n: data["n"].ToString(),
+						e: data["e"].ToString(),
+						rsaJsonWebKey: out RsaJsonWebKey rsaJsonWebKey
+					) ) {
+						throw new JsonWebKeyParseException( "decoded 'n' parameter starts with 0 byte in RSA JSON web key" );
+					}
+
+					return rsaJsonWebKey;
 
 				case "EC":
 					if( !data.ContainsKey( "crv" ) ) {

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
@@ -62,6 +62,15 @@ namespace D2L.Security.OAuth2.Keys {
 		}
 
 		[Test]
+		public void FromJson_Modulus0PrefixThrows() {
+			string id = Guid.NewGuid().ToString();
+			string example =
+				@"{""kid"":""" + id + @""",""kty"":""RSA"",""use"":""sig"",""n"":""AKYl5hffy9FDuCuQD8x6ojmJfyrVVwID5VR4VKKT87WlvyUYdpPTA3rqSANXABfUv6-akQVnANUGj9J5RmpcN45v30h77VGGIcFIRfV-iNfVUZr_wV_TXtm7nbeXWnyPQ2zbNi7atF_8nzNXVC_Nb2kdK8-42GkOWxdgkUB1QnCIVpIpPOTxuXNciv_wLPONlqqIAaVvPs7BKAerOdxTaQxt-_x7GQAJ4AE5k2NQLeDu4wuqfnNClTw39uaC1TDlkLm8lYAhPRZbFcaax1qrF3p5ZxxJoWXxGxQf-SgeoY9sle-44by0bJTb8in5RQbOgBgonMzQ85qFx9hldxQFSxU"",""e"":""AQAB""}";
+
+			Assert.Throws<JsonWebKeyParseException>( () => JsonWebKey.FromJson( example ) );
+		}
+
+		[Test]
 		public async Task FromJson_GeneratedKeyRoundTrips() {
 			IPrivateKeyProvider privateKeyProvider = new RsaPrivateKeyProvider(
 				new D2LSecurityTokenFactory(


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.1, we should reject RSA JSON web keys with decoded modulus that starts with a 0 byte. 