### PR TITLE
Have GetSigningCredentialsAsync refresh its key earlier

### DIFF
--- a/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
+++ b/src/D2L.Security.OAuth2/Keys/KeyManagementService.cs
@@ -17,6 +17,20 @@ namespace D2L.Security.OAuth2.Keys {
 
 		private D2LSecurityToken m_current = null;
 
+		// This controls how long the background refresh is going to wait for a
+		// new key to be generated
+		private static readonly TimeSpan BackgroundRefreshDelay = TimeSpan.FromMinutes( 1 );
+
+		// This controls how frequently background refresh will retry if it
+		// doesn't find a key
+		private static readonly TimeSpan BackgroundRefreshRetryDelay = TimeSpan.FromMinutes( 1 );
+
+		// Wait for the delay and some number of retries before making GetSigningCredentials
+		// do a foreground Refresh
+		private static readonly TimeSpan GetSigningCredentialsRefreshGracePeriod
+			= BackgroundRefreshDelay
+			+ BackgroundRefreshRetryDelay + BackgroundRefreshRetryDelay;
+
 		internal KeyManagementService(
 			IPublicKeyDataProvider publicKeys,
 			IPrivateKeyDataProvider privateKeys,
@@ -51,7 +65,9 @@ namespace D2L.Security.OAuth2.Keys {
 
 			var now = m_clock.UtcNow;
 
-			if ( current == null || ExpectedTimeOfNewUsableKey( current ) < now ) {
+			if ( current == null
+				|| ExpectedTimeOfNewUsableKey( current ) + GetSigningCredentialsRefreshGracePeriod < now
+			) {
 				// Slow path: RefreshKeyAsync() wasn't called on boot and/or it
 				// isn't being called in a background job.
 				await RefreshKeyAsync( now )
@@ -93,11 +109,11 @@ namespace D2L.Security.OAuth2.Keys {
 			if( now > expectedTimeOfNewUsableKey ) {
 				// If we would have expected a new key by now, retry again in a
 				// bit. This code branch supports configuration changes mostly.
-				return TimeSpan.FromMinutes( 1 );
+				return BackgroundRefreshRetryDelay;
 			} else {
 				// Otherwise use that but with a little buffer for key
 				// generation time/imprecisely scheduled cron jobs.
-				return expectedTimeOfNewUsableKey.AddMinutes( 1 ) - now;
+				return expectedTimeOfNewUsableKey + BackgroundRefreshDelay - now;
 			}
 		}
 


### PR DESCRIPTION
Only refreshing after the key is expired will cause us to sign tokens that might not validate for their entire lifetime.

The spirit was to have GetSigningCredentialsAsync call RefreshAsync even if there was no background job calling it -- so this change makes it call it at the same cadence/time we expect a background service to.

This hasn't been a problem in production for various reasons but it was for a specific use-case in the dev environment, but regardless its a bug.