### PR TITLE
LFT-1285 - Suppress sync generator in .NET Core build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 	<ItemGroup>
     	<PackageVersion  Include="BenchmarkDotNet" Version="0.13.1" />
-		<PackageVersion  Include="D2L.CodeStyle.Analyzers" Version="0.203.0" />
+		<PackageVersion  Include="D2L.CodeStyle.Analyzers" Version="0.214.0" />
 		<PackageVersion  Include="D2L.CodeStyle.Annotations" Version="0.31.0" />
 		<PackageVersion  Include="D2L.Services.Core.Exceptions" Version="2.0.1.15" />
 		<PackageVersion  Include="FluentAssertions" Version="6.6.0" />

--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -10,6 +10,10 @@
 		<IncludeSymbols>true</IncludeSymbols>
 	</PropertyGroup>
 
+  <ItemGroup>
+    <CompilerVisibleProperty Include="SuppressSyncGenerator" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="D2L.CodeStyle.Analyzers">
 			<PrivateAssets>All</PrivateAssets>
@@ -24,6 +28,10 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 	</ItemGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net60'">
+		<SuppressSyncGenerator>true</SuppressSyncGenerator>
+	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net60'">
 		<!-- We use Microsoft.Extensions.Caching.Memory in .NET 5+ -->


### PR DESCRIPTION
We don't need the sync implementations but we especially don't want the obligations to implement sync APIs in .NET Core. The spirit of the generator is to make migrating to sync in .NET Framework sustainable, the idea generally is that in .NET Core we won't rely on sync APIs.