### PR TITLE
update to Microsoft.IdentityModel.JsonWebTokens

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 		<PackageVersion  Include="RichardSzalay.MockHttp" Version="6.0.0" />
 		<PackageVersion  Include="SimpleLogInterface" Version="3.0.1" />
 		<PackageVersion  Include="System.Collections.Immutable" Version="6.0.0" />
-		<PackageVersion  Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" />
+		<PackageVersion  Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.36.0" />
 		<PackageVersion  Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
 </Project>

--- a/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
+++ b/src/D2L.Security.OAuth2/D2L.Security.OAuth2.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="D2L.CodeStyle.Annotations" />
 		<PackageReference Include="D2L.Services.Core.Exceptions" />
 		<PackageReference Include="System.Collections.Immutable" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">

--- a/src/D2L.Security.OAuth2/Keys/Default/TokenSigner.cs
+++ b/src/D2L.Security.OAuth2/Keys/Default/TokenSigner.cs
@@ -1,14 +1,15 @@
-﻿using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Security.Claims;
+﻿using Microsoft.IdentityModel.JsonWebTokens;
 using System.Threading.Tasks;
 using D2L.CodeStyle.Annotations;
 using D2L.Security.OAuth2.Validation.Exceptions;
+using Microsoft.IdentityModel.Tokens;
+using System.Collections.Generic;
 
 namespace D2L.Security.OAuth2.Keys.Default {
 	public sealed partial class TokenSigner : ITokenSigner {
 
 		private readonly IPrivateKeyProvider m_privateKeyProvider;
+		private readonly JsonWebTokenHandler m_tokenHandler = new() { SetDefaultTimesOnTokenCreation = false };
 
 		public TokenSigner(
 			IKeyManagementService keyManagementService
@@ -22,31 +23,28 @@ namespace D2L.Security.OAuth2.Keys.Default {
 
 		[GenerateSync]
 		async Task<string> ITokenSigner.SignAsync( UnsignedToken token ) {
-			JwtSecurityToken jwt;
 			using( D2LSecurityToken securityToken = await m_privateKeyProvider
 				.GetSigningCredentialsAsync()
 				.ConfigureAwait( false )
 			) {
-				jwt = new JwtSecurityToken(
-					issuer: token.Issuer,
-					audience: token.Audience,
-					claims: Enumerable.Empty<Claim>(),
-					notBefore: token.NotBefore,
-					expires: token.ExpiresAt,
-					signingCredentials: securityToken.GetSigningCredentials()
-				);
+				SecurityTokenDescriptor jwt = new SecurityTokenDescriptor() {
+					Issuer = token.Issuer,
+					Audience = token.Audience,
+					NotBefore = token.NotBefore,
+					Expires = token.ExpiresAt,
+					SigningCredentials = securityToken.GetSigningCredentials(),
+					Claims = new Dictionary<string, object>(),
+				};
 
 				var claims = token.Claims;
 				foreach( var claim in claims ) {
-					if( jwt.Payload.ContainsKey( claim.Key ) ) {
+					if( jwt.Claims.ContainsKey( claim.Key ) ) {
 						throw new ValidationException( $"'{claim.Key}' is already part of the payload" );
 					}
-					jwt.Payload.Add( claim.Key, claim.Value );
+					jwt.Claims.Add( claim.Key, claim.Value );
 				}
 
-				var jwtHandler = new JwtSecurityTokenHandler();
-
-				string signedRawToken = jwtHandler.WriteToken( jwt );
+				string signedRawToken = m_tokenHandler.CreateToken( jwt );
 
 				return signedRawToken;
 			}

--- a/src/D2L.Security.OAuth2/Provisioning/Default/CachedAccessTokenProvider.cs
+++ b/src/D2L.Security.OAuth2/Provisioning/Default/CachedAccessTokenProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -10,16 +10,12 @@ using D2L.Security.OAuth2.Scopes;
 using D2L.Services;
 using D2L.CodeStyle.Annotations;
 
-#if DNXCORE50
-using System.IdentityModel.Tokens.Jwt;
-#endif
-
 namespace D2L.Security.OAuth2.Provisioning.Default {
 	internal sealed partial class CachedAccessTokenProvider : IAccessTokenProvider {
 		private readonly INonCachingAccessTokenProvider m_accessTokenProvider;
 		private readonly Uri m_authEndpoint;
 		private readonly TimeSpan m_tokenRefreshGracePeriod;
-		private readonly JwtSecurityTokenHandler m_tokenHandler;
+		private readonly JsonWebTokenHandler m_tokenHandler = new();
 
 		public CachedAccessTokenProvider(
 			INonCachingAccessTokenProvider accessTokenProvider,
@@ -29,8 +25,6 @@ namespace D2L.Security.OAuth2.Provisioning.Default {
 			m_accessTokenProvider = accessTokenProvider;
 			m_authEndpoint = authEndpoint;
 			m_tokenRefreshGracePeriod = tokenRefreshGracePeriod;
-
-			m_tokenHandler = new JwtSecurityTokenHandler();
 		}
 
 		[GenerateSync]

--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessToken.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessToken.cs
@@ -1,23 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
 using System.Security.Claims;
 using D2L.CodeStyle.Annotations;
 using static D2L.CodeStyle.Annotations.Objects;
-
-#if DNXCORE50
-using System.IdentityModel.Tokens.Jwt;
-#endif
 
 namespace D2L.Security.OAuth2.Validation.AccessTokens {
 	[Immutable]
 	internal sealed class AccessToken : IAccessToken {
 		[Mutability.Audited( "Todd Lang", "02-Mar-2018", ".Net class we can't modify, but is used immutably." )]
-		private readonly JwtSecurityToken m_inner;
+		private readonly JsonWebToken m_inner;
 		private readonly IAccessToken m_this;
 
-		internal AccessToken( JwtSecurityToken jwtSecurityToken ) {
+		internal AccessToken( JsonWebToken jwtSecurityToken ) {
 			m_inner = jwtSecurityToken;
 			m_this = this;
 		}
@@ -35,7 +30,7 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 		}
 
 		string IAccessToken.SensitiveRawAccessToken {
-			get { return m_inner.RawData; }
+			get { return m_inner.EncodedToken; }
 		}
 	}
 }

--- a/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
+++ b/test/D2L.Security.OAuth2.IntegrationTests/D2L.Security.OAuth2.IntegrationTests.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net60'">

--- a/test/D2L.Security.OAuth2.UnitTests/D2L.Security.OAuth2.UnitTests.csproj
+++ b/test/D2L.Security.OAuth2.UnitTests/D2L.Security.OAuth2.UnitTests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 

--- a/test/D2L.Security.OAuth2.UnitTests/Validation/AccessTokenValidatorTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Validation/AccessTokenValidatorTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
 using System.Threading.Tasks;
 using D2L.Security.OAuth2.Keys.Default;
 using D2L.Security.OAuth2.TestUtilities;
@@ -83,14 +83,14 @@ namespace D2L.Security.OAuth2.Validation {
 				signingCredentials = signingToken.GetSigningCredentials();
 			}
 
-			var jwtToken = new JwtSecurityToken(
-				issuer: "someissuer",
-				signingCredentials: signingCredentials,
-				expires: jwtExpiry
-			);
+			SecurityTokenDescriptor jwtToken = new() {
+				Issuer = "someissuer",
+				SigningCredentials = signingCredentials,
+				Expires = jwtExpiry
+			};
 
-			var tokenHandler = new JwtSecurityTokenHandler();
-			string serializedJwt = tokenHandler.WriteToken( jwtToken );
+			JsonWebTokenHandler tokenHandler = new() { SetDefaultTimesOnTokenCreation = false };
+			string serializedJwt = tokenHandler.CreateToken( jwtToken );
 
 			IPublicKeyProvider publicKeyProvider = PublicKeyProviderMock.Create(
 				m_jwksEndpoint,


### PR DESCRIPTION
Looks like a definite improvement. Need to spend a bit more time with it. Unit test is failing due to different claim order.

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
AMD Ryzen Threadripper PRO 7945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
  [Host]     : .NET Framework 4.8 (4.8.9256.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.9256.0), X64 RyuJIT


| Method |        Mean |    Error |   StdDev | Rank |
|------- |------------:|---------:|---------:|-----:|
|  ES256 | 1,216.47 us | 3.676 us | 3.259 us |    4 |
|  ES384 |   552.58 us | 3.321 us | 2.944 us |    3 |
|  ES512 |   255.73 us | 2.874 us | 2.548 us |    2 |
|  RS256 |    56.07 us | 0.444 us | 0.415 us |    1 |
```

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
AMD Ryzen Threadripper PRO 7945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
  [Host]     : .NET Framework 4.8 (4.8.9256.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.9256.0), X64 RyuJIT


| Method |        Mean |    Error |   StdDev | Rank |
|------- |------------:|---------:|---------:|-----:|
|  ES256 | 1,198.32 us | 6.115 us | 5.107 us |    4 |
|  ES384 |   540.46 us | 2.511 us | 2.348 us |    3 |
|  ES512 |   243.52 us | 1.124 us | 0.996 us |    2 |
|  RS256 |    41.21 us | 0.303 us | 0.283 us |    1 |
```