### PR TITLE
LFT-1689 - Completely remove Newtonsoft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - v*
 
 env:
-  VERSION_PREFIX: 14.1.0
+  VERSION_PREFIX: 14.2.0
 
 jobs:
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
 		<PackageVersion  Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
 		<PackageVersion  Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageVersion  Include="Moq" Version="4.18.1" />
-		<PackageVersion  Include="Newtonsoft.Json" Version="[6.0.8,7)" />
 		<PackageVersion  Include="NUnit" Version="3.14.0" />
 		<PackageVersion  Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageVersion  Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/src/D2L.Security.OAuth2.TestFramework/D2L.Security.OAuth2.TestFramework.csproj
+++ b/src/D2L.Security.OAuth2.TestFramework/D2L.Security.OAuth2.TestFramework.csproj
@@ -15,7 +15,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net60'">
-		<PackageReference Include="Newtonsoft.Json" />
 		<Reference Include="System.Net.Http" />
 	</ItemGroup>
 

--- a/test/D2L.Security.OAuth2.Benchmarks/D2L.Security.OAuth2.Benchmarks.csproj
+++ b/test/D2L.Security.OAuth2.Benchmarks/D2L.Security.OAuth2.Benchmarks.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
+++ b/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using D2L.Security.OAuth2.Keys;
 using D2L.Security.OAuth2.Keys.Development;
 using D2L.Security.OAuth2.Utilities;
 using D2L.Security.OAuth2.Validation.AccessTokens;
-using Newtonsoft.Json;
 using RichardSzalay.MockHttp;
 
 namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {

--- a/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
+++ b/test/D2L.Security.OAuth2.Benchmarks/FullStackValidation/FullStackValidationBenchmark.cs
@@ -69,7 +69,7 @@ namespace D2L.Security.OAuth2.Benchmarks.FullStackValidation {
 
 			mockHandler
 				.When( "http://localhost/.well-known/jwks" )
-				.Respond( "application/json", JsonConvert.SerializeObject( new { keys = new object[] { jwk.ToJwkDto() } } ) );
+				.Respond( "application/json", JsonSerializer.Serialize( new { keys = new object[] { jwk.ToJwkDto() } } ) );
 		}
 	}
 }

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
@@ -84,10 +84,10 @@ namespace D2L.Security.OAuth2.Keys {
 			D2LSecurityToken token = await privateKeyProvider.GetSigningCredentialsAsync().ConfigureAwait( false );
 			JsonWebKey expectedKey = token.ToJsonWebKey();
 
-			string expectedJson = JsonConvert.SerializeObject( expectedKey.ToJwkDto() );
+			string expectedJson = JsonSerializer.Serialize( expectedKey.ToJwkDto() );
 
 			JsonWebKey actualKey = JsonWebKey.FromJson( expectedJson );
-			string actualJson = JsonConvert.SerializeObject( actualKey.ToJwkDto() );
+			string actualJson = JsonSerializer.Serialize( actualKey.ToJwkDto() );
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt.Value.ToUnixTimeSeconds(), actualKey.ExpiresAt.Value.ToUnixTimeSeconds() );
@@ -109,10 +109,10 @@ namespace D2L.Security.OAuth2.Keys {
 				expectedKey = token.ToJsonWebKey();
 			}
 
-			string expectedJson = JsonConvert.SerializeObject( expectedKey.ToJwkDto() );
+			string expectedJson = JsonSerializer.Serialize( expectedKey.ToJwkDto() );
 
 			JsonWebKey actualKey = JsonWebKey.FromJson( expectedJson );
-			string actualJson = JsonConvert.SerializeObject( actualKey.ToJwkDto() );
+			string actualJson = JsonSerializer.Serialize( actualKey.ToJwkDto() );
 
 			Assert.AreEqual( expectedKey.Id, actualKey.Id );
 			Assert.AreEqual( expectedKey.ExpiresAt.Value.ToUnixTimeSeconds(), actualKey.ExpiresAt.Value.ToUnixTimeSeconds() );

--- a/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
+++ b/test/D2L.Security.OAuth2.UnitTests/Keys/JsonWebKeyTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Security.Cryptography;
+using System.Text.Json;
 using System.Threading.Tasks;
 using D2L.Security.OAuth2.Keys.Default;
 using D2L.Security.OAuth2.Utilities;
 using D2L.Services;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace D2L.Security.OAuth2.Keys {


### PR DESCRIPTION
In #374 I forgot how the TestFramework package gets used, so I also want to remove Newtonsoft there. To keep it simple I removed it everywhere.