### PR TITLE
LFT-2887: Catch SecurityTokenInvalidSignatureException in AccessTokenValidator

### DIFF
--- a/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidator.cs
+++ b/src/D2L.Security.OAuth2/Validation/AccessTokens/AccessTokenValidator.cs
@@ -92,6 +92,8 @@ namespace D2L.Security.OAuth2.Validation.AccessTokens {
 				throw new ExpiredTokenException( e );
 			} catch( SecurityTokenNotYetValidException e ) {
 				throw new ValidationException( "Token is from the future (nbf)", e );
+			} catch( SecurityTokenInvalidSignatureException e ) {
+				throw new ValidationException( "Invalid signature", e );
 			} catch( Exception e ) {
 				throw new ValidationException( "Unknown validation exception", e );
 			}


### PR DESCRIPTION
Noticed this while diagnosing a customer issue; I'm surprised we didn't have a custom error message for this case already.